### PR TITLE
chore(deploy): surface only required env vars in app compose

### DIFF
--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -6,14 +6,20 @@
 # separate container — anything reachable over the network). Platform-agnostic:
 # works on any Docker Compose host (Coolify, Portainer, `docker compose up`, ...).
 #
-#   - DATABASE_URL (from .env) must point at the external Postgres.
-#   - the api applies Alembic migrations on startup (RUN_MIGRATIONS=true).
-#   - no Redis / worker: executions run in-process ("regular" mode). To scale
-#     out later, add redis + an `arq` worker and set EXECUTION_QUEUE_ENABLED=true.
+# Config model:
+#   - Required runtime settings are declared inline as ${VAR} (no defaults), so a
+#     platform like Coolify surfaces exactly them in its UI as fields to fill:
+#       DATABASE_URL, JWT_SECRET_KEY, ENCRYPTION_KEY.
+#   - Everything else uses the app's built-in defaults. Add optional overrides
+#     (e.g. SYSTEM_OPENAI_API_KEY, CORS_ALLOWED_ORIGINS, HOST_URL) as extra
+#     `NAME: ${NAME}` lines under `api.environment` and set them in the platform.
+#   - The api applies Alembic migrations on startup (RUN_MIGRATIONS=true).
+#   - No Redis / worker: executions run in-process ("regular" mode). To scale out
+#     later, add redis + an `arq` worker and set EXECUTION_QUEUE_ENABLED=true.
 #
-# Only `web` is public: nginx serves the SPA and proxies /api -> api:8000 over
-# the internal network, so neither service publishes host ports — the platform's
-# reverse proxy routes the domain to web:80.
+# Only `web` is public: nginx serves the SPA and proxies /api -> api:8000 over the
+# internal network. `api` deliberately has no exposed/published port, so the
+# platform does not assign it a public domain.
 # ============================================================================
 
 name: assemblix
@@ -24,12 +30,13 @@ services:
       context: ./assemblix-app-api
       target: prod
     image: assemblix-api:latest
-    env_file: .env
     environment:
       # Apply `alembic upgrade head` against the external DB before uvicorn starts.
       RUN_MIGRATIONS: "true"
-    expose:
-      - "8000"
+      # --- Required — fill these in the deploy platform (Coolify env vars) ---
+      DATABASE_URL: ${DATABASE_URL}        # external Postgres, e.g. postgresql://user:pass@host:5432/db
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}    # JWT signing secret, >= 32 chars
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}    # Fernet key for stored credentials
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').status==200 else 1)"]
       interval: 15s
@@ -43,14 +50,12 @@ services:
     build:
       context: ./assemblix-app-web
       args:
-        VITE_API_BASE_URL: ${VITE_API_BASE_URL:-/api}
-        VITE_APP_VERSION: ${VITE_APP_VERSION:-1.0.0}
-        VITE_LANGS: ${VITE_LANGS:-ru,en}
-        VITE_DEFAULT_LANGUAGE: ${VITE_DEFAULT_LANGUAGE:-ru}
-        VITE_SUPPORTED_LANGUAGES: ${VITE_SUPPORTED_LANGUAGES:-ru,en}
-        VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID:-}
-        VITE_GITHUB_CLIENT_ID: ${VITE_GITHUB_CLIENT_ID:-}
-        VITE_YANDEX_CLIENT_ID: ${VITE_YANDEX_CLIENT_ID:-}
+        # Same-origin API path — nginx proxies /api -> api:8000. Fixed, not configurable.
+        VITE_API_BASE_URL: /api
+        # English-only bundle (overrides the web image's ru,en default).
+        VITE_LANGS: en
+        VITE_DEFAULT_LANGUAGE: en
+        VITE_SUPPORTED_LANGUAGES: en
     image: assemblix-web:latest
     expose:
       - "80"


### PR DESCRIPTION
## What
Reworks `docker-compose.app.yml` so a Docker Compose host (Coolify) surfaces **only the truly required** env vars, drops the `ru` locale, and stops exposing the API publicly.

## Changes
- **Required vars inline as `${VAR}`** (no defaults) → Coolify shows exactly these as fields to fill: `DATABASE_URL`, `JWT_SECRET_KEY`, `ENCRYPTION_KEY`. Removed `env_file: .env` (the gitignored file is absent in the repo clone → fragile on Coolify).
- **English-only build** — `VITE_LANGS`/`VITE_DEFAULT_LANGUAGE`/`VITE_SUPPORTED_LANGUAGES` pinned to `en`, `VITE_API_BASE_URL` hard-coded to `/api`. No `VITE_*` vars leak into the env surface; no `ru` bundled.
- **API stays internal** — removed `expose: 8000` from `api` so the platform assigns it no public domain; `web` still reaches it over the network (`api:8000`).

## Coolify follow-up (UI)
After deploying this branch, the auto-prefilled leftovers can be cleaned up:
- delete the now-unused `VITE_*` vars and the `SERVICE_FQDN_API` / `SERVICE_URL_API` (api needs no domain);
- keep the domain only on `web`;
- fill `DATABASE_URL`, `JWT_SECRET_KEY`, `ENCRYPTION_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)