### PR TITLE
fix(agent): always return all declared response-schema fields

### DIFF
--- a/assemblix-app-api/assemblix_api/nodes/agent_node.py
+++ b/assemblix-app-api/assemblix_api/nodes/agent_node.py
@@ -196,9 +196,10 @@ class AgentNode(BaseNode):
             return None, parse_json
 
         if self.typed_config.response_schema:
+            schema = _enforce_strict_schema(self.typed_config.response_schema)
             return {
                 "type": "json_schema",
-                "json_schema": {"name": "response", "schema": self.typed_config.response_schema},
+                "json_schema": {"name": "response", "schema": schema, "strict": True},
             }, parse_json
         return {"type": "json_object"}, parse_json
 
@@ -272,6 +273,27 @@ class AgentNode(BaseNode):
             color="node-llm",
             properties=[],
         )
+
+
+def _enforce_strict_schema(node: object) -> object:
+    """Recursively force every object to require all its declared properties and
+    forbid extras, so structured-output providers always return the whole schema.
+
+    The frontend never emits a `required` array, so without this a provider (Gemini,
+    non-strict OpenAI) treats every field as optional and may drop any the model chose
+    not to fill. Pure and side-effect-free: returns a new structure, leaving the input
+    (the node's stored `response_schema`) untouched.
+    """
+    if isinstance(node, list):
+        return [_enforce_strict_schema(item) for item in node]
+    if not isinstance(node, dict):
+        return node
+    result = {key: _enforce_strict_schema(value) for key, value in node.items()}
+    properties = result.get("properties")
+    if isinstance(properties, dict):
+        result["required"] = list(properties.keys())
+        result["additionalProperties"] = False
+    return result
 
 
 def _split_system_messages(messages: list[dict]) -> tuple[str, list[dict]]:

--- a/assemblix-app-api/tests/unit/nodes/test_agent_node.py
+++ b/assemblix-app-api/tests/unit/nodes/test_agent_node.py
@@ -26,7 +26,7 @@ import types
 import pytest
 
 from assemblix_api.enums import PlanTier
-from assemblix_api.nodes.agent_node import AgentNode
+from assemblix_api.nodes.agent_node import AgentNode, _enforce_strict_schema
 
 from ._helpers import build_node, make_context, node_input
 
@@ -228,3 +228,106 @@ async def test_agent_requires_credential_service() -> None:
     # Act + Assert
     with pytest.raises(AssertionError):
         await node.execute(node_input({"message": "hi"}, context))
+
+
+# --- Structured output: force every declared field to be returned -----------------
+# The frontend never emits a `required` array, so providers (Gemini, non-strict OpenAI)
+# treat all fields as optional and may drop unfilled ones. `_enforce_strict_schema`
+# recursively marks every object property required + forbids extras, and the request
+# adds `strict: true`, so the whole schema always comes back.
+
+_REPORTED_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "is_end": {"type": "boolean"},
+        "response_text": {"type": "string"},
+    },
+    "additionalProperties": False,
+    "title": "responseSchema",
+}
+
+
+def test_enforce_strict_schema_injects_required_flat() -> None:
+    """A flat object with no `required` gets every property marked required."""
+    # Act
+    out = _enforce_strict_schema(_REPORTED_SCHEMA)
+
+    # Assert
+    assert out["required"] == ["is_end", "response_text"]
+    assert out["additionalProperties"] is False
+    assert out["title"] == "responseSchema"  # cosmetic keys pass through
+
+
+def test_enforce_strict_schema_recurses_nested_objects_and_arrays() -> None:
+    """Nested objects and array-of-object items each get their own `required`."""
+    # Arrange
+    schema = {
+        "type": "object",
+        "properties": {
+            "meta": {"type": "object", "properties": {"x": {"type": "string"}}},
+            "rows": {
+                "type": "array",
+                "items": {"type": "object", "properties": {"y": {"type": "number"}}},
+            },
+        },
+    }
+
+    # Act
+    out = _enforce_strict_schema(schema)
+
+    # Assert
+    assert out["required"] == ["meta", "rows"]
+    assert out["properties"]["meta"]["required"] == ["x"]
+    assert out["properties"]["meta"]["additionalProperties"] is False
+    assert out["properties"]["rows"]["items"]["required"] == ["y"]
+    assert out["properties"]["rows"]["items"]["additionalProperties"] is False
+
+
+def test_enforce_strict_schema_overrides_partial_required() -> None:
+    """A hand-written partial `required` is widened to all properties."""
+    # Arrange
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "string"}, "b": {"type": "string"}},
+        "required": ["a"],
+    }
+
+    # Act
+    out = _enforce_strict_schema(schema)
+
+    # Assert
+    assert out["required"] == ["a", "b"]
+
+
+def test_enforce_strict_schema_does_not_mutate_input() -> None:
+    """The normalizer returns a new structure and leaves the input untouched."""
+    # Arrange
+    import copy
+
+    original = copy.deepcopy(_REPORTED_SCHEMA)
+
+    # Act
+    _enforce_strict_schema(_REPORTED_SCHEMA)
+
+    # Assert
+    assert _REPORTED_SCHEMA == original
+
+
+async def test_agent_json_schema_forces_all_fields_required(mock_llm) -> None:
+    """The request carries the strict, all-fields-required response_format."""
+    # Arrange
+    mock_llm.set_response(json.dumps({"is_end": True, "response_text": "bye"}))
+    context = _agent_context()
+    node = _agent({"response_format": "json_object", "response_schema": dict(_REPORTED_SCHEMA)})
+
+    # Act
+    await node.execute(node_input({"message": "Hello there"}, context))
+
+    # Assert
+    sent = mock_llm.calls[0]["response_format"]
+    assert sent["type"] == "json_schema"
+    assert sent["json_schema"]["name"] == "response"
+    assert sent["json_schema"]["strict"] is True
+    inner = sent["json_schema"]["schema"]
+    assert inner["required"] == ["is_end", "response_text"]
+    assert inner["additionalProperties"] is False

--- a/assemblix-app-web/src/shared/i18n/index.ts
+++ b/assemblix-app-web/src/shared/i18n/index.ts
@@ -20,13 +20,35 @@ AVAILABLE_LANGS.forEach((lang) => {
   }
 });
 
+// Only these languages actually ship translations (currently English only).
+// `AVAILABLE_LANGS` / `DEFAULT_LANG` come from build-time env and may name a
+// language we don't bundle yet — resolving to it leaves the UI without strings.
+const BUNDLED_LANGS = Object.keys(resources);
+const FALLBACK_LANG = BUNDLED_LANGS.includes(DEFAULT_LANG) ? DEFAULT_LANG : "en";
+
+// Returning users may have cached a now-unbundled language (e.g. "ru") from an
+// earlier build, which left their UI without English strings. Force everyone
+// back onto a bundled language by dropping that stale cache before detection
+// runs. Self-healing on every load; also corrects the value read for the API
+// `Accept-Language` header (see shared/api/baseApi.ts).
+try {
+  const cached = localStorage.getItem("i18nextLng");
+  if (cached && !BUNDLED_LANGS.includes(cached)) {
+    localStorage.setItem("i18nextLng", FALLBACK_LANG);
+  }
+} catch {
+  // localStorage unavailable (e.g. privacy mode) — detection falls back safely.
+}
+
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     resources,
-    fallbackLng: DEFAULT_LANG,
-    supportedLngs: AVAILABLE_LANGS,
+    fallbackLng: FALLBACK_LANG,
+    // Restrict to bundled languages so neither localStorage nor navigator can
+    // select a language we don't ship translations for.
+    supportedLngs: BUNDLED_LANGS,
     interpolation: {
       escapeValue: false,
     },


### PR DESCRIPTION
Два независимых фикса в одной ветке.

---

## 1. fix(agent): всегда возвращать все поля response-схемы

### Проблема
При structured output в AGENT-ноде модель могла молча **не возвращать часть полей**. Воспроизведено на Gemini со схемой:

```json
{"type":"object","properties":{"is_end":{"type":"boolean"},"response_text":{"type":"string"}},"additionalProperties":false,"title":"responseSchema"}
```

В ответе отсутствовал `is_end`. Ожидание: если пользователь заполнил JSON-схему — все её поля всегда возвращаются.

### Причина
- Фронт (`json-schema-builder`) кладёт `required`, только если поле помечено обязательным, но в Simple-режиме тумблера required/optional нет → `required` не эмитится никогда.
- Бэк (`AgentNode._resolve_response_format`) пробрасывал схему в `litellm.acompletion` **как есть** — без `required`, без `strict`.

Без `required`/strict провайдер считает все поля опциональными → Gemini (и не-strict OpenAI) вправе выкинуть любое. Ответ потом только `json.loads`-ится без валидации.

### Фикс
Рекурсивный нормализатор `_enforce_strict_schema`: перед отправкой помечает **все** свойства каждого объекта как `required` + `additionalProperties:false`, обёртка получает `strict:true`. Покрывает вложенные объекты и массивы объектов, исходную схему не мутирует. Работает для всех провайдеров; существующие воркфлоу чинятся автоматически (правок фронта/миграций не требуется).

**Вне рамок:** при включённых `tools` `response_format` намеренно не отправляется (конфликт со структурным выводом; Gemini не умеет tools + native structured output). Этот путь не менялся.

### Тесты
5 новых тестов в `tests/unit/nodes/test_agent_node.py`. Весь unit-набор: **66 passed**. `ruff`, `ruff format`, `mypy` — чисто.

---

## 2. fix(i18n): принудительный английский при застрявшем небандленном языке

### Проблема
Бандлится только английский, но у вернувшихся пользователей в localStorage мог застрять язык (например `ru`) из старого билда. i18next резолвился в него → UI без строк. То же значение уходило в `Accept-Language`-хедер API.

### Фикс (`shared/i18n/index.ts`)
- До запуска детектора: если закешированный `i18nextLng` — не забандленный язык, переписываем его на `en` (self-healing на каждой загрузке; чинит и API-хедер, и `i18n.language`-проверки).
- Сузили `supportedLngs`/`fallbackLng` до реально забандленных языков, чтобы и `navigator` не мог выбрать язык без переводов.

Итог: все с `ru`/любым небандленным языком принудительно получают `en`; на en-пользователей влияния нет.

### Проверка
`tsc -b` — exit 0 (жёсткий гейт фронт-CI), `eslint` по файлу — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)