### PR TITLE
feat(i18n): add Spanish and Russian as selectable UI languages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,9 +99,9 @@ CONCURRENCY_ACQUIRE_TIMEOUT_SECONDS=30  # wait for a free slot before proceeding
 VITE_API_BASE_URL=/api     # SPA API base; keep /api (nginx/Vite proxy forward it)
 VITE_APP_URL=              # public app URL for API code samples; blank = current browser host
 VITE_APP_VERSION=1.0.0
-VITE_LANGS=en              # locales to build; the two below are runtime hints
+VITE_LANGS=en,es,ru        # locales to build; the two below are runtime hints
 VITE_DEFAULT_LANGUAGE=en
-VITE_SUPPORTED_LANGUAGES=en
+VITE_SUPPORTED_LANGUAGES=en,es,ru
 VITE_GOOGLE_CLIENT_ID=     # OAuth client IDs (public); blank to hide
 VITE_GITHUB_CLIENT_ID=
 VITE_YANDEX_CLIENT_ID=

--- a/assemblix-app-web/src/pages/settings/ui/SettingsPage.tsx
+++ b/assemblix-app-web/src/pages/settings/ui/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from "@/shared/lib/theme-context";
 import { Button } from "@/shared/ui/button";
+import { LanguageSwitcher } from "@/shared/ui/language-switcher";
 import { useTranslation } from "react-i18next";
 
 export const SettingsPage = () => {
@@ -179,6 +180,11 @@ export const SettingsPage = () => {
             {t("settings.systemTheme")}
           </Button>
         </div>
+      </section>
+
+      <section className="bg-card p-6 rounded-xl border border-border shadow-sm">
+        <h2 className="text-xl font-semibold mb-4">{t("settings.language")}</h2>
+        <LanguageSwitcher className="w-full max-w-xs" />
       </section>
 
       <div className="grid gap-12">

--- a/assemblix-app-web/src/shared/i18n/index.ts
+++ b/assemblix-app-web/src/shared/i18n/index.ts
@@ -3,6 +3,8 @@ import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 
 import en from "./locales/en.json";
+import es from "./locales/es.json";
+import ru from "./locales/ru.json";
 
 // Available languages come from build-time env vars.
 export const AVAILABLE_LANGS =
@@ -11,19 +13,27 @@ export const AVAILABLE_LANGS =
 export const DEFAULT_LANG =
   typeof __DEFAULT_LANG__ !== "undefined" ? __DEFAULT_LANG__ : "en";
 
-// Build the resources object only with available languages.
+// Every language we ship translations for. Adding a new one is a single entry
+// here plus a locale file — no other change to this module.
+const ALL_TRANSLATIONS: Record<string, { translation: typeof en }> = {
+  en: { translation: en },
+  es: { translation: es },
+  ru: { translation: ru },
+};
+
+// Build the resources object only with available languages that we bundle.
 const resources: Record<string, { translation: typeof en }> = {};
 
 AVAILABLE_LANGS.forEach((lang) => {
-  if (lang === "en") {
-    resources.en = { translation: en };
+  if (ALL_TRANSLATIONS[lang]) {
+    resources[lang] = ALL_TRANSLATIONS[lang];
   }
 });
 
-// Only these languages actually ship translations (currently English only).
+// The languages that actually ship translations in this build.
 // `AVAILABLE_LANGS` / `DEFAULT_LANG` come from build-time env and may name a
 // language we don't bundle yet — resolving to it leaves the UI without strings.
-const BUNDLED_LANGS = Object.keys(resources);
+export const BUNDLED_LANGS = Object.keys(resources);
 const FALLBACK_LANG = BUNDLED_LANGS.includes(DEFAULT_LANG) ? DEFAULT_LANG : "en";
 
 // Returning users may have cached a now-unbundled language (e.g. "ru") from an

--- a/assemblix-app-web/src/shared/i18n/languages.ts
+++ b/assemblix-app-web/src/shared/i18n/languages.ts
@@ -1,0 +1,7 @@
+// Native language names shown in the language switcher. Names stay in their own
+// language regardless of the active UI locale, so they need no translation keys.
+export const LANGUAGE_LABELS: Record<string, string> = {
+  en: "English",
+  es: "Español",
+  ru: "Русский",
+};

--- a/assemblix-app-web/src/shared/i18n/locales/en.json
+++ b/assemblix-app-web/src/shared/i18n/locales/en.json
@@ -514,6 +514,7 @@
     "lightTheme": "Light",
     "darkTheme": "Dark",
     "systemTheme": "System",
+    "language": "Language",
     "tabs": {
       "general": "General",
       "apiKeys": "API keys",

--- a/assemblix-app-web/src/shared/i18n/locales/es.json
+++ b/assemblix-app-web/src/shared/i18n/locales/es.json
@@ -1,0 +1,1343 @@
+{
+  "footer": {
+    "terms": "Términos de servicio",
+    "privacy": "Política de privacidad",
+    "refund": "Política de reembolso",
+    "contact": "Contáctanos"
+  },
+  "notFoundPage": {
+    "title": "Parece que llegaste a un callejón sin salida",
+    "subtitle": "Esta página no existe — el camino terminó en un 404. Vamos a ponerte de nuevo en marcha.",
+    "home": "Ir al inicio",
+    "back": "Volver"
+  },
+  "common": {
+    "save": "Guardar",
+    "update": "Actualizar",
+    "cancel": "Cancelar",
+    "delete": "Eliminar",
+    "create": "Crear",
+    "edit": "Editar",
+    "close": "Cerrar",
+    "confirm": "Confirmar",
+    "loading": "Cargando...",
+    "yes": "Sí",
+    "no": "No",
+    "back": "Atrás",
+    "next": "Siguiente",
+    "search": "Buscar",
+    "actions": "Acciones",
+    "status": "Estado",
+    "name": "Nombre",
+    "type": "Tipo",
+    "value": "Valor",
+    "description": "Descripción",
+    "createdAt": "Creado",
+    "updatedAt": "Actualizado",
+    "optional": "opcional",
+    "required": "obligatorio",
+    "total": "Total",
+    "showMore": "Mostrar más",
+    "showLess": "Mostrar menos",
+    "or": "o",
+    "locale": "es"
+  },
+  "auth": {
+    "login": "Iniciar sesión",
+    "register": "Registrarse",
+    "logout": "Cerrar sesión",
+    "email": "Correo electrónico",
+    "password": "Contraseña",
+    "confirmPassword": "Confirmar contraseña",
+    "fullName": "Nombre completo",
+    "name": "Nombre",
+    "forgotPassword": "¿Olvidaste tu contraseña?",
+    "signIn": "Entrar",
+    "signUp": "Crear cuenta",
+    "createAccount": "Crear cuenta",
+    "enterCredentials": "Introduce tus credenciales para iniciar sesión",
+    "registerDescription": "Crea una cuenta para empezar a usar Assemblix",
+    "user": "Usuario",
+    "emailValidation": "Por favor, introduce un correo electrónico válido.",
+    "emailPlaceholder": "tu@email.com",
+    "namePlaceholder": "Tu nombre",
+    "passwordMinLength": "La contraseña debe contener al menos 3 caracteres.",
+    "passwordsNotMatch": "Las contraseñas no coinciden",
+    "nameMinLength": "El nombre debe contener al menos 2 caracteres.",
+    "loginError": "Error al iniciar sesión",
+    "registerError": "Error de registro",
+    "registerErrorDescription": "Inténtalo de nuevo más tarde o usa otro correo electrónico",
+    "invalidCredentials": "Correo electrónico o contraseña incorrectos",
+    "noAccount": "¿No tienes cuenta?",
+    "hasAccount": "¿Ya tienes cuenta?",
+    "oauth": {
+      "continueWithGoogle": "Continuar con Google",
+      "continueWithGitHub": "Continuar con GitHub",
+      "continueWithYandex": "Continuar con Yandex",
+      "googleError": "Error al iniciar sesión con Google",
+      "googleErrorDescription": "No se pudo iniciar sesión con Google. Inténtalo de nuevo.",
+      "githubError": "Error al iniciar sesión con GitHub",
+      "githubErrorDescription": "No se pudo iniciar sesión con GitHub. Inténtalo de nuevo.",
+      "githubProcessing": "Completando el inicio de sesión con GitHub...",
+      "githubStateMismatch": "Parámetro state no válido — inicia sesión de nuevo",
+      "emailAlreadyRegistered": "El correo electrónico ya está registrado",
+      "emailAlreadyRegisteredDescription": "Este correo ya está registrado con una contraseña. Inicia sesión mediante el formulario o restablece tu contraseña.",
+      "emailNotVerified": "Correo electrónico no verificado",
+      "emailNotVerifiedDescription": "Por favor, verifica tu correo electrónico en tu cuenta de Google.",
+      "cancelled": "Inicio de sesión cancelado por el usuario"
+    }
+  },
+  "header": {
+    "appName": "Assemblix",
+    "lightTheme": "Tema claro",
+    "darkTheme": "Tema oscuro",
+    "language": "Idioma",
+    "help": "Ayuda",
+    "organizationSettings": "Configuración de la organización"
+  },
+  "sidebar": {
+    "agents": "Agentes",
+    "agentSessions": "Llamadas de agentes",
+    "apiKeys": "Claves API",
+    "knowledgeBases": "Bases de conocimiento",
+    "organization": "Organización",
+    "credentials": "Credenciales",
+    "clientSessions": "Sesiones de clientes",
+    "projectSettings": "Configuración del proyecto",
+    "settings": "Configuración",
+    "community": "Comunidad",
+    "sections": {
+      "creation": "Crear",
+      "monitoring": "Monitoreo"
+    }
+  },
+  "home": {
+    "title": "Crea tu agente",
+    "subtitle": "Crea y gestiona tus agentes de IA con un editor visual",
+    "createAgent": "Crear nuevo agente"
+  },
+  "sessions": {
+    "title": "Llamadas de agentes",
+    "subtitle": "Historial de chats y ejecuciones de tus agentes",
+    "tabs": {
+      "chats": "Chats",
+      "executions": "Ejecuciones"
+    },
+    "showTestSessions": "Mostrar sesiones de prueba"
+  },
+  "agents": {
+    "title": "Agentes",
+    "createAgent": "Crear agente",
+    "noAgents": "Todavía no tienes agentes",
+    "createFirstAgent": "Crea tu primer agente para empezar",
+    "lastModified": "Última modificación",
+    "published": "Publicado",
+    "draft": "Borrador",
+    "selectProject": "Seleccionar proyecto",
+    "createError": "Error al crear el agente",
+    "publishSuccess": "Agente publicado correctamente",
+    "publishError": "Error al publicar el agente",
+    "deleteSuccess": "Agente eliminado",
+    "deleteError": "Error al eliminar el agente",
+    "renameSuccess": "Agente renombrado",
+    "renameError": "Error al renombrar el agente"
+  },
+  "workflow": {
+    "nodes": {
+      "start": "Inicio",
+      "agent": "Agente",
+      "sticker": "Nota",
+      "condition": "Condición",
+      "setVariable": "Establecer variable",
+      "end": "Fin",
+      "httpRequest": "Solicitud HTTP",
+      "newElement": "Nuevo elemento"
+    },
+    "nodeDefaults": {
+      "agentName": "Nuevo agente",
+      "endName": "Éxito"
+    },
+    "nodeDescriptions": {
+      "start": "Punto de entrada del flujo de trabajo",
+      "agent": "Llamada al LLM con parámetros",
+      "sticker": "Añadir nota",
+      "condition": "Comprobación de condición lógica",
+      "setVariable": "Asignar valor a una variable",
+      "end": "Fin de la ejecución del flujo de trabajo",
+      "httpRequest": "Solicitud HTTP a una API externa"
+    },
+    "categories": {
+      "main": "Principal",
+      "logic": "Lógica",
+      "data": "Datos",
+      "integrations": "Integraciones"
+    },
+    "sidebar": {
+      "selectNodeType": "Selecciona el tipo de nodo",
+      "clickToSelect": "Haz clic en el elemento deseado abajo"
+    },
+    "stateSidebar": {
+      "title": "Gestión de estado",
+      "agentState": "Estado del agente",
+      "projectState": "Estado del proyecto",
+      "live": "LIVE",
+      "noVariables": "No hay variables de estado",
+      "readOnlyHint": "El flujo de trabajo está en ejecución — edición deshabilitada"
+    },
+    "header": {
+      "debug": "Depurar",
+      "publish": "Publicar",
+      "published": "Publicado",
+      "debugMode": "Modo de depuración",
+      "exitDebug": "Salir de depuración",
+      "editMode": "Modo de edición",
+      "workMode": "Modo de trabajo",
+      "publishError": "No se pudo publicar el flujo de trabajo",
+      "agentCalls": "Llamadas de agentes"
+    },
+    "agentCalls": {
+      "title": "Llamadas de agentes",
+      "executions": "Ejecuciones",
+      "chats": "Chats",
+      "noExecutions": "No hay ejecuciones para este agente",
+      "noChats": "No hay chats para este agente",
+      "selectChat": "Selecciona un chat para verlo"
+    },
+    "bulkInstructions": {
+      "title": "Instrucciones de los agentes",
+      "openTooltip": "Editar las instrucciones de todos los agentes",
+      "emptyTooltip": "No hay nodos de agente en este flujo de trabajo",
+      "searchPlaceholder": "Buscar agente...",
+      "unnamedAgent": "Agente #{{index}}",
+      "noAgentsFound": "No se encontraron agentes",
+      "selectAgentHint": "Selecciona un agente a la izquierda para editar sus instrucciones",
+      "emptyState": "Este flujo de trabajo aún no tiene nodos de agente. Añade un agente al lienzo para empezar a editar las instrucciones.",
+      "addInstruction": "Añadir instrucción"
+    },
+    "rename": {
+      "title": "Renombrar agente",
+      "namePlaceholder": "Nombre del agente",
+      "nameRequired": "El nombre es obligatorio",
+      "nameMinLength": "El nombre debe contener al menos 3 caracteres"
+    },
+    "publish": {
+      "title": "Agente publicado",
+      "description": "Tu agente se ha publicado correctamente y está listo para usarse",
+      "close": "Cerrar"
+    },
+    "versions": {
+      "draft": "Borrador",
+      "version": "Versión",
+      "current": "Actual"
+    },
+    "editor": {
+      "nodeEditor": "Editor de nodos",
+      "unknownNodeType": "Tipo de nodo desconocido",
+      "loadingNodeTypes": "Cargando tipos de nodos…",
+      "data": "Datos"
+    },
+    "details": {
+      "loadingError": "Error de carga",
+      "loadingErrorDescription": "No se pudieron cargar los datos del agente. Puede que haya sido eliminado o que no tengas acceso.",
+      "backToList": "Volver a la lista",
+      "versionLoadError": "Error",
+      "versionLoadErrorDescription": "No se pudo cargar la versión"
+    },
+    "node": {
+      "agent": {
+        "warnings": {
+          "modelNotSelected": "Modelo no seleccionado"
+        }
+      }
+    }
+  },
+  "provider": {
+    "openai": "OpenAI",
+    "gemini": "Gemini",
+    "deepseek": "DeepSeek",
+    "temperature": "Temperatura",
+    "temperatureHelp": "Controla la aleatoriedad de las respuestas (0-2)"
+  },
+  "credentials": {
+    "title": "Gestionar credenciales",
+    "subtitle": "Añade y edita claves API para usarlas en los flujos de trabajo",
+    "addCredential": "Añadir credencial",
+    "addFirstCredential": "Añadir primera credencial",
+    "noCredentials": "Todavía no tienes credenciales guardadas",
+    "type": "Tipo",
+    "selectType": "Seleccionar tipo",
+    "name": "Nombre",
+    "namePlaceholder": "Mi clave API",
+    "nameMinLength": "El nombre debe contener al menos 3 caracteres",
+    "value": "Valor",
+    "newValue": "Nuevo valor (opcional)",
+    "valuePlaceholder": "sk-...",
+    "newValuePlaceholder": "Introduce un nuevo valor o déjalo vacío",
+    "valueRequired": "El valor es obligatorio",
+    "createSuccess": "Credencial creada",
+    "createError": "No se pudo crear la credencial",
+    "updateSuccess": "Credencial actualizada",
+    "updateError": "No se pudo actualizar la credencial",
+    "deleteSuccess": "Credencial eliminada",
+    "deleteError": "No se pudo eliminar la credencial",
+    "deleteConfirm": "¿Eliminar la credencial?",
+    "deleteWarning": "¿Seguro que quieres eliminar \"{{name}}\"? Esta acción no se puede deshacer.",
+    "untitled": "Sin título",
+    "selectCredentialType": "Por favor, selecciona un tipo de credencial",
+    "select": {
+      "placeholder": "Seleccionar credencial",
+      "title": "Credenciales",
+      "description": "Selecciona una credencial para usar",
+      "noKeys": "No hay claves disponibles. Añade tu primera credencial.",
+      "add": "Añadir credencial"
+    },
+    "systemToken": {
+      "name": "Token del sistema Assemblix",
+      "description": "Usa nuestros tokens para empezar rápido. Se descuentan créditos por el uso del LLM."
+    }
+  },
+  "apiKeys": {
+    "title": "Claves API",
+    "subtitle": "Gestiona las claves API para la autenticación en tu aplicación",
+    "createKey": "Crear clave API",
+    "createFirstKey": "Crear primera clave",
+    "noKeys": "Todavía no tienes claves API",
+    "noKeysDescription": "Crea tu primera clave API para empezar a trabajar con la API",
+    "name": "Nombre",
+    "key": "Clave",
+    "created": "Creada",
+    "lastUsed": "Último uso",
+    "requests": "Solicitudes",
+    "neverUsed": "Nunca usada",
+    "totalKeys": "Total de claves",
+    "createSuccess": "Clave API creada correctamente",
+    "createError": "Error al crear la clave API",
+    "deleteSuccess": "Clave API eliminada correctamente",
+    "deleteError": "Error al eliminar la clave API",
+    "copySuccess": "Clave copiada al portapapeles",
+    "copyError": "No se pudo copiar la clave",
+    "copyKey": "Copiar clave",
+    "justNow": "justo ahora",
+    "minutesAgo": "hace {{count}} min",
+    "hoursAgo": "hace {{count}} h",
+    "daysAgo": "hace {{count}} d",
+    "deleteConfirm": "¿Eliminar la clave API?",
+    "deleteWarning": "¿Seguro que quieres eliminar \"{{name}}\"? La clave dejará de funcionar de inmediato y esta acción no se puede deshacer.",
+    "enterKeyName": "Introduce el nombre de la clave",
+    "selectProject": "Seleccionar proyecto",
+    "modal": {
+      "createTitle": "Crear clave API",
+      "createDescription": "Introduce un nombre para la nueva clave API. Esto te ayudará a identificarla más adelante.",
+      "saveTitle": "Guarda tu clave API",
+      "saveWarning": "¡Importante! Copia y guarda esta clave en un lugar seguro.",
+      "saveDescription": "No se mostrará de nuevo. Si la pierdes, tendrás que crear una nueva clave.",
+      "yourKey": "Tu clave API",
+      "namePlaceholder": "p. ej., Production API Key",
+      "creating": "Creando...",
+      "done": "Listo, he guardado la clave",
+      "useInHeader": "Usa esta clave en el encabezado Authorization:"
+    },
+    "delete": {
+      "title": "¿Eliminar la clave API?",
+      "description": "¿Seguro que quieres eliminar la clave",
+      "warning": "La clave dejará de funcionar de inmediato y esta acción no se puede deshacer.",
+      "deleting": "Eliminando..."
+    }
+  },
+  "chats": {
+    "title": "Chats",
+    "noChats": "Todavía no tienes chats",
+    "noChatsDescription": "Los chats aparecerán aquí después de crearse",
+    "agent": "Agente",
+    "messages": "mensajes",
+    "lastMessage": "Último mensaje",
+    "active": "Activo",
+    "inactive": "Inactivo",
+    "credits": "Créditos:",
+    "infoBanner": {
+      "title": "📬 Los chats de tus agentes aparecerán aquí",
+      "description": "Cuando ejecutes un agente con el parámetro create_session: true, aparecerá aquí una sesión de chat con el historial completo de la conversación y estadísticas."
+    },
+    "rename": "Renombrar",
+    "delete": "Eliminar",
+    "deleteTitle": "Eliminar sesión",
+    "deleteDescription": "Esto eliminará permanentemente la sesión y todos los mensajes. Esta acción no se puede deshacer.",
+    "renameLabel": "Nombre de la sesión",
+    "renamePlaceholder": "Introduce el nombre de la sesión...",
+    "cancel": "Cancelar"
+  },
+  "chatDetails": {
+    "title": "Chat del",
+    "sendMessage": "Enviar mensaje",
+    "typePlaceholder": "Escribe un mensaje...",
+    "agent": "Agente",
+    "user": "Usuario",
+    "notFound": "Chat no encontrado",
+    "noMessages": "No hay mensajes en este chat",
+    "goToExecution": "Ir a la ejecución",
+    "credits": "créditos"
+  },
+  "executions": {
+    "title": "Ejecuciones",
+    "noExecutions": "Todavía no tienes ejecuciones",
+    "noExecutionsDescription": "El historial de ejecuciones de agentes aparecerá aquí",
+    "agent": "Agente",
+    "status": "Estado",
+    "started": "Iniciada",
+    "duration": "Duración",
+    "steps": "Pasos:",
+    "credits": "Créditos:",
+    "clientSession": "Sesión de cliente",
+    "filterByClientId": "Filtrar por Client ID...",
+    "statuses": {
+      "running": "En ejecución",
+      "completed": "Completada",
+      "failed": "Fallida",
+      "pending": "Pendiente"
+    },
+    "infoBanner": {
+      "title": "🚀 Las ejecuciones de tus agentes aparecerán aquí",
+      "description": "Cada ejecución de un agente publicado crea un registro en el historial. Verás los detalles de la ejecución, los tokens usados, el costo y los resultados."
+    }
+  },
+  "executionViewer": {
+    "title": "Visor de ejecuciones",
+    "step": "Paso",
+    "stepNumber": "Paso n.º",
+    "input": "Datos de entrada",
+    "output": "Datos de salida",
+    "error": "Error",
+    "errorMessage": "Mensaje de error",
+    "errorExecution": "Error de ejecución",
+    "errorInNode": "Error en el nodo:",
+    "logs": "Registros",
+    "backToExecutions": "Volver a ejecuciones",
+    "back": "Atrás",
+    "duration": "Duración",
+    "credits": "Créditos",
+    "steps": "Pasos",
+    "executionFrom": "Ejecución del",
+    "model": "Modelo",
+    "stateBefore": "Estado antes",
+    "stateAfter": "Estado después",
+    "celEvaluations": "Evaluaciones CEL",
+    "llmRequest": "Solicitud al LLM",
+    "currentState": "Estado",
+    "stateAfterStep": "Estado tras el paso",
+    "stateChanges": "Cambios",
+    "fullState": "Estado completo",
+    "noChanges": "Este nodo no realizó cambios de estado",
+    "loadingError": "Error de carga",
+    "loadingErrorDescription": "No se pudieron cargar los datos de la ejecución. Puede que haya sido eliminada o que no tengas acceso."
+  },
+  "organization": {
+    "title": "Configuración de la organización",
+    "subtitle": "Gestiona la configuración básica y los miembros de la organización",
+    "members": "Miembros",
+    "membersCount_one": "miembro",
+    "membersCount_other": "miembros",
+    "projects": "Proyectos",
+    "addMember": "Añadir miembro",
+    "removeMember": "Eliminar miembro",
+    "email": "Correo electrónico",
+    "role": "Rol",
+    "actions": "Acciones",
+    "member": "Miembro",
+    "joinedDate": "Fecha de ingreso",
+    "noMembers": "No hay miembros",
+    "noMembersDescription": "Añade el primer miembro a la organización",
+    "noName": "Sin nombre",
+    "selectOrganization": "Seleccionar organización",
+    "selectProject": "Seleccionar proyecto",
+    "createProject": "Crear proyecto",
+    "addOrganization": "Añadir organización",
+    "addProject": "Añadir proyecto",
+    "createOrganization": "Crear organización",
+    "organizationName": "Nombre de la organización",
+    "organizationNamePlaceholder": "p. ej., Mi equipo",
+    "projectName": "Nombre del proyecto",
+    "projectNamePlaceholder": "p. ej., Production",
+    "enterOrganizationName": "Introduce el nombre de la organización",
+    "enterProjectName": "Introduce un nombre para el nuevo proyecto",
+    "organizationCreated": "Organización creada",
+    "projectCreated": "Proyecto creado",
+    "organizationCreateError": "No se pudo crear la organización",
+    "projectCreateError": "No se pudo crear el proyecto",
+    "creating": "Creando...",
+    "saving": "Guardando...",
+    "enterName": "Introduce el nombre de la organización",
+    "enterProjectNameError": "Introduce el nombre del proyecto",
+    "selectOrganizationFirst": "Selecciona una organización",
+    "nameNotChanged": "El nombre no ha cambiado",
+    "nameUpdated": "Nombre de la organización actualizado",
+    "nameUpdateError": "Error al actualizar el nombre",
+    "onlyOwnerCanEdit": "Solo el propietario puede cambiar el nombre de la organización",
+    "basicSettings": "Configuración básica",
+    "organizationInfo": "Información de la organización",
+    "roles": {
+      "owner": "Propietario",
+      "admin": "Administrador",
+      "member": "Miembro"
+    },
+    "addMemberModal": {
+      "title": "Añadir miembro",
+      "description": "Introduce el correo electrónico de un usuario que ya esté registrado en el sistema.",
+      "emailPlaceholder": "user@example.com",
+      "selectRole": "Seleccionar rol",
+      "isOwner": "Propietario de la organización",
+      "isOwnerDescription": "Los propietarios pueden añadir y eliminar miembros",
+      "addSuccess": "Miembro añadido correctamente",
+      "addError": "Error al añadir el miembro",
+      "userNotFound": "No se encontró un usuario con este correo electrónico",
+      "userAlreadyMember": "El usuario ya es miembro de la organización",
+      "noPermission": "Permisos insuficientes para añadir miembros",
+      "enterEmail": "Introduce el correo electrónico del miembro",
+      "enterValidEmail": "Introduce un correo electrónico válido",
+      "adding": "Añadiendo..."
+    },
+    "removeMemberModal": {
+      "title": "¿Eliminar miembro?",
+      "description": "¿Seguro que quieres eliminar a",
+      "fromOrganization": "de la organización?",
+      "warning": "El miembro perderá el acceso a todos los proyectos y recursos de la organización. Esta acción puede revertirse añadiendo al miembro de nuevo.",
+      "removeSuccess": "Miembro eliminado de la organización",
+      "removeError": "Error al eliminar el miembro",
+      "cannotRemoveOwner": "No se puede eliminar al propietario de la organización",
+      "noPermission": "Permisos insuficientes para eliminar miembros",
+      "deleting": "Eliminando..."
+    }
+  },
+  "settings": {
+    "title": "Configuración",
+    "subtitle": "Paleta de colores utilizada en el sistema",
+    "theme": "Tema",
+    "lightTheme": "Claro",
+    "darkTheme": "Oscuro",
+    "systemTheme": "Sistema",
+    "language": "Idioma",
+    "tabs": {
+      "general": "General",
+      "apiKeys": "Claves API",
+      "credentials": "Credenciales",
+      "notifications": "Notificaciones"
+    },
+    "colorCategories": {
+      "basic": "Colores básicos",
+      "accents": "Acentos",
+      "statuses": "Estados",
+      "workflowNodes": "Nodos del flujo de trabajo",
+      "borders": "Bordes y elementos",
+      "sidebar": "Barra lateral"
+    }
+  },
+  "notifications": {
+    "title": "Notificaciones",
+    "subtitle": "Canales que reciben alertas sobre fallos técnicos en la ejecución de los flujos de trabajo. Se aplica a todos los flujos de trabajo del proyecto.",
+    "empty": "Aún no hay canales de notificación configurados",
+    "addFirst": "Añadir primer canal",
+    "add": "Añadir canal",
+    "untitled": "Sin título",
+    "disabled": "Deshabilitado",
+    "enabled": "Canal habilitado",
+    "type": "Tipo de origen",
+    "name": "Nombre",
+    "namePlaceholder": "p. ej., Alertas de prod",
+    "botToken": "Token del bot",
+    "botTokenPlaceholder": "123456:ABC-DEF...",
+    "botTokenEditPlaceholder": "Déjalo vacío para mantener el actual",
+    "botTokenRequired": "El token del bot es obligatorio",
+    "chatId": "Chat ID",
+    "chatIdPlaceholder": "-1001234567890",
+    "chatIdRequired": "El Chat ID es obligatorio",
+    "test": "Probar",
+    "testSuccess": "Mensaje de prueba enviado",
+    "testError": "No se pudo enviar el mensaje de prueba",
+    "createSuccess": "Canal creado",
+    "createError": "No se pudo crear el canal",
+    "updateSuccess": "Canal actualizado",
+    "updateError": "No se pudo actualizar el canal",
+    "deleteConfirm": "¿Eliminar el canal?",
+    "deleteWarning": "El canal \"{{name}}\" se eliminará permanentemente.",
+    "deleteSuccess": "Canal eliminado",
+    "deleteError": "No se pudo eliminar el canal"
+  },
+  "errors": {
+    "generic": "Se produjo un error",
+    "networkError": "Error de red",
+    "unauthorized": "Se requiere autorización",
+    "forbidden": "Acceso denegado",
+    "notFound": "No encontrado",
+    "serverError": "Error del servidor"
+  },
+  "variables": {
+    "title": "Variables",
+    "addVariable": "Añadir variable",
+    "noVariables": "No hay variables disponibles",
+    "availableVariables": "Variables disponibles",
+    "state": "Estado",
+    "input": "Entrada"
+  },
+  "nodeForms": {
+    "start": {
+      "title": "Inicio",
+      "firstPhrase": "Primera frase",
+      "firstPhraseHint": "Saludo del asistente que se añade al historial como primer mensaje cuando comienza una nueva sesión.",
+      "firstPhrasePlaceholder": "¡Hola! ¿En qué puedo ayudarte?",
+      "inputVariables": "Variables de entrada",
+      "projectVariables": "Variables del proyecto",
+      "projectVariablesNote": "Estas variables se definen a nivel de proyecto y están disponibles en todos los flujos de trabajo",
+      "stateVariables": "Variables de estado",
+      "add": "Añadir",
+      "variableUpdateError": "Error al actualizar la variable",
+      "variableAddError": "Error al añadir la variable",
+      "variableUpdated": "Variable \"{{name}}\" actualizada",
+      "variableAdded": "Variable \"{{name}}\" añadida",
+      "variableDeleteError": "Error al eliminar la variable",
+      "variableDeleted": "Variable eliminada"
+    },
+    "end": {
+      "title": "Fin",
+      "endpointPlaceholder": "p. ej., Éxito, Error",
+      "isSessionEnd": "Finalizar sesión",
+      "sessionEndDescription": "La sesión pasará a estar inactiva. Úsalo como indicador de que el diálogo ha terminado.",
+      "isError": "Error de negocio",
+      "isErrorDescription": "Marcar la finalización como un rechazo deliberado del agente (estado ERROR en lugar de COMPLETED)",
+      "errorMessage": "Mensaje de error",
+      "errorMessagePlaceholder": "{{state.error_reason}}",
+      "advancedSettings": "Configuración avanzada",
+      "outputSource": "Origen de la salida",
+      "outputModeLastAgent": "Último agente",
+      "outputModeSpecificAgent": "Agente específico",
+      "outputModeCustom": "Mensaje fijo",
+      "selectAgent": "Seleccionar agente",
+      "agentLabel": "Agente",
+      "goToAgent": "Ir al agente",
+      "customMessage": "Mensaje",
+      "customMessagePlaceholder": "{{input.message}} o texto fijo",
+      "dataFiltering": "Filtrado de datos",
+      "stateFilter": "Variables de estado",
+      "projectFilter": "Variables del proyecto",
+      "filterAll": "Todas",
+      "filterNone": "No devolver",
+      "filterSelected": "Seleccionadas",
+      "selectVariables": "Seleccionar variables",
+      "noAgents": "No hay agentes disponibles",
+      "properties": "Propiedades (JSON)",
+      "propertiesPlaceholder": "{\n  \"status\": \"success\",\n  \"message\": \"Workflow completed\"\n}",
+      "invalidJSON": "⚠️ JSON no válido. Debe ser un objeto.",
+      "propertiesHelp": "Introduce un objeto JSON con propiedades adicionales para el nodo final",
+      "preview": "Vista previa:"
+    },
+    "sticker": {
+      "title": "Nota",
+      "text": "Texto de la nota",
+      "placeholder": "Escribe tu nota..."
+    },
+    "condition": {
+      "title": "Condición",
+      "conditions": "Condiciones",
+      "expression": "Expresión {{number}}",
+      "expressionPlaceholder": "state.counter > 10",
+      "branchName": "Nombre de la rama",
+      "branchPlaceholder": "p. ej., high_count",
+      "add": "Añadir condición",
+      "defaultBranch": "Por defecto",
+      "defaultBranchPlaceholder": "default",
+      "namePlaceholder": "Introduce el nombre de la condición"
+    },
+    "setVariable": {
+      "title": "Establecer variable",
+      "updates": "Actualizaciones de variables",
+      "variable": "Variable {{number}}",
+      "selectVariable": "Seleccionar variable",
+      "value": "Valor",
+      "valuePlaceholder": "state.counter + 1",
+      "add": "Añadir actualización",
+      "advancedUsage": "Uso avanzado",
+      "merges": "Fusión inteligente",
+      "merge": "Fusión {{number}}",
+      "addMerge": "Añadir fusión",
+      "mergeSource": "Origen",
+      "mergeSourcePlaceholder": "input.parsed_message",
+      "mergeTargetKey": "Variable de estado",
+      "mergeTargetKeyAll": "Estado completo",
+      "mergeTarget": "Destino",
+      "mergeTargetState": "Estado",
+      "mergeTargetProject": "Proyecto",
+      "mergeOperation": "Operación",
+      "mergeOperationAdd": "Sumar (+)",
+      "mergeOperationSubtract": "Restar (−)",
+      "mergeOperationOverwrite": "Sobrescribir (=)"
+    },
+    "agent": {
+      "title": "Agente",
+      "name": "Nombre",
+      "namePlaceholder": "Introduce el nombre del agente",
+      "provider": "Proveedor",
+      "selectProvider": "Seleccionar proveedor",
+      "model": "Modelo",
+      "modelPlaceholder": "gpt-4, gemini-pro, etc.",
+      "selectModel": "Seleccionar modelo",
+      "advancedSettings": "Configuración avanzada",
+      "maxRetries": "Reintentos ante errores transitorios",
+      "maxRetriesPlaceholder": "Por defecto",
+      "timeout": "Tiempo de espera, segundos",
+      "timeoutPlaceholder": "Por defecto",
+      "enforceTimeoutOnLast": "Tiempo de espera estricto en el último modelo",
+      "enforceTimeoutOnLastTooltip": "Cuando está habilitado, el tiempo de espera por llamada también se aplica al último modelo de la cadena, de modo que ningún proveedor pueda bloquear la ejecución. Cuando está deshabilitado, el último modelo puede ejecutarse hasta el tiempo de espera general como último recurso.",
+      "fallbackModels": "Modelos de respaldo",
+      "fallbackModelsHint": "Se prueban en orden cuando el modelo principal sigue fallando con errores transitorios (límites de tasa, 5xx).",
+      "fallbackModelItem": "Respaldo {{index}}",
+      "addFallbackModel": "Añadir modelo",
+      "searchModel": "Buscar modelo...",
+      "loadingModels": "Cargando modelos...",
+      "modelsError": "Error al cargar los modelos",
+      "noModels": "No hay modelos disponibles",
+      "noModelsFound": "No se encontraron modelos",
+      "credential": "Clave de acceso",
+      "selectCredential": "Seleccionar clave",
+      "selectCredentialFirst": "Selecciona primero una clave de acceso",
+      "instructions": "Instrucciones",
+      "role": "Rol",
+      "selectRole": "Seleccionar rol",
+      "roleUser": "Usuario",
+      "roleAssistant": "Asistente",
+      "contentPlaceholder": "Introduce el contenido de la instrucción",
+      "expandInstruction": "Expandir prompt",
+      "promptModalTitle": "Editar instrucción",
+      "promptModalLabel": "Instrucción",
+      "additionalSettings": "Configuración adicional",
+      "tools": "Herramientas",
+      "allToolsAdded": "Todas añadidas",
+      "addTool": "Añadir herramienta",
+      "responseFormat": "Formato de respuesta",
+      "selectFormat": "Seleccionar formato",
+      "formatText": "Texto",
+      "formatJSON": "Objeto JSON",
+      "schemaBuilder": "Constructor de esquemas JSON",
+      "schemaDescription": "Crea la estructura de la respuesta JSON para el modelo LLM",
+      "cancel": "Cancelar",
+      "save": "Guardar",
+      "includeChatHistory": "Historial del chat",
+      "includeChatHistoryTooltip": "Cuando está habilitado, se enviará al LLM el historial completo del diálogo de la sesión. Cuando está deshabilitado, solo se enviarán las instrucciones del nodo y el mensaje actual del usuario",
+      "saveToHistory": "Guardar la respuesta en el historial",
+      "saveToHistoryTooltip": "Cuando está habilitado, la respuesta de este agente se añade al historial de diálogo compartido que ven los agentes posteriores. Deshabilítalo para hacer que el agente sea silencioso — su respuesta seguirá fluyendo al siguiente nodo y a la salida final, pero no al historial compartido.",
+      "historyField": "Campo del historial",
+      "historyFieldTooltip": "Cuando la respuesta es JSON, guarda solo este campo del esquema en el historial compartido en lugar del JSON completo. La respuesta completa sigue fluyendo hacia adelante y hacia la salida final.",
+      "historyFieldFull": "Respuesta completa",
+      "knowledgeBases": "Bases de conocimiento",
+      "selectKnowledgeBases": "Añadir base de conocimiento",
+      "noKnowledgeBases": "No hay bases de conocimiento",
+      "noKnowledgeBasesFound": "No se encontraron bases de conocimiento",
+      "loadingKnowledgeBases": "Cargando bases de conocimiento...",
+      "searchKnowledgeBases": "Buscar base de conocimiento...",
+      "modelSettings": "Configuración del modelo",
+      "modelSettingsTooltip": "Parámetros avanzados de la llamada al LLM: temperatura, penalizaciones, formato de respuesta, razonamiento y otras opciones según el modelo",
+      "modelSettingsModalTitle": "Configuración del modelo",
+      "modelSettingsModalDescription": "Ajusta con precisión los parámetros de la llamada al LLM. Los campos disponibles dependen del modelo seleccionado.",
+      "close": "Cerrar"
+    },
+    "generic": {
+      "jsonPlaceholder": "{ \"key\": \"value\" }"
+    },
+    "httpRequest": {
+      "title": "Solicitud HTTP",
+      "method": "Método",
+      "selectMethod": "Seleccionar método",
+      "url": "URL",
+      "urlPlaceholder": "https://api.example.com/endpoint",
+      "headers": "Encabezados",
+      "headerKey": "Clave",
+      "headerValue": "Valor",
+      "queryParams": "Parámetros de consulta",
+      "paramKey": "Clave",
+      "paramValue": "Valor",
+      "body": "Cuerpo de la solicitud",
+      "bodyPlaceholder": "{\"key\": \"value\"}",
+      "timeout": "Tiempo de espera (seg)"
+    }
+  },
+  "debug": {
+    "title": "Chat de depuración",
+    "running": "En ejecución",
+    "clearHistory": "Borrar el historial e iniciar una nueva sesión",
+    "noMessages": "No hay mensajes",
+    "noMessagesHelp": "Escribe un mensaje abajo y ejecuta el flujo de trabajo",
+    "userMessage": "Tú:",
+    "error": "Error:",
+    "inputPlaceholder": "Por ejemplo: ¡Hola! ¿Cómo estás?",
+    "execute": "Ejecutar",
+    "stop": "Detener",
+    "executing": "Ejecutando...",
+    "step": "Paso {{number}}:",
+    "completed": "Completado",
+    "failed": "Fallido",
+    "input": "Entrada",
+    "output": "Salida",
+    "duration": "{{ms}} ms",
+    "executionResult": "Resultado de la ejecución",
+    "inputData": "Datos de entrada",
+    "outputData": "Datos de salida",
+    "llmRequest": "Solicitud al LLM",
+    "stateBefore": "Estado antes",
+    "stateAfter": "Estado después",
+    "projectStateAfter": "Estado del proyecto después",
+    "noData": "Sin datos",
+    "creditsUsed": "Créditos",
+    "ownKeyCost": "Clave propia",
+    "totalCost": "Total",
+    "executionError": "La ejecución terminó con un error",
+    "sessionClosed": "Sesión cerrada",
+    "sessionClosedDesc": "El agente cerró la sesión. Puedes continuar o iniciar una nueva sesión",
+    "continueSession": "Continuar sesión",
+    "startNewSession": "Iniciar nueva sesión",
+    "stateManagement": "Gestión de estado",
+    "agentState": "Estado del agente",
+    "projectState": "Estado del proyecto",
+    "noStateVariables": "No hay variables de estado",
+    "noProjectVariables": "No hay variables del proyecto",
+    "invalidJson": "Formato JSON no válido",
+    "resetToDefault": "Restablecer"
+  },
+  "nodes": {
+    "condition": {
+      "else": "Si no"
+    },
+    "placeholder": {
+      "newElement": "Nuevo elemento",
+      "selectTypeInSidebar": "Selecciona el tipo en la barra lateral"
+    }
+  },
+  "stateVariables": {
+    "noVariablesText": "No hay variables. Añade tu primera variable.",
+    "selectTitle": "Variables de estado",
+    "selectDescription": "Selecciona la variable a actualizar",
+    "selectPlaceholder": "Seleccionar variable",
+    "noAvailableVariables": "No hay variables disponibles. Crea la primera variable.",
+    "addVariable": "Añadir variable",
+    "defaultValueLabel": "valor por defecto"
+  },
+  "availableVariables": {
+    "operators": {
+      "comparison": {
+        "equal": "Igual",
+        "notEqual": "Distinto",
+        "less": "Menor que",
+        "greater": "Mayor que",
+        "lessOrEqual": "Menor o igual",
+        "greaterOrEqual": "Mayor o igual"
+      },
+      "logical": {
+        "ternary": "Operador ternario",
+        "or": "O lógico",
+        "and": "Y lógico"
+      },
+      "comparisonTitle": "Comparación",
+      "logicalTitle": "Lógica",
+      "notFound": "No se encontraron operadores",
+      "noAvailable": "No hay operadores disponibles"
+    },
+    "variablesNotFound": "No se encontraron variables",
+    "noAvailableVariables": "No hay variables disponibles",
+    "groups": {
+      "input": "Datos de entrada",
+      "state": "Estado",
+      "project": "Proyecto",
+      "workflow": "Agente",
+      "metadata": "Metadatos"
+    }
+  },
+  "workflowCard": {
+    "noDescription": "Sin descripción"
+  },
+  "versionsDropdown": {
+    "draft": "Borrador",
+    "error": "Error",
+    "loadVersionError": "No se pudo cargar la versión"
+  },
+  "workflowActions": {
+    "additionalActions": "Acciones adicionales",
+    "rename": "Renombrar",
+    "renameAgent": "Renombrar agente",
+    "renameDescription": "Introduce un nuevo nombre para el agente",
+    "nameLabel": "Nombre",
+    "namePlaceholder": "Nombre del agente",
+    "nameMinLength": "El nombre debe contener al menos 3 caracteres",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "renamed": "Flujo de trabajo renombrado",
+    "renameError": "No se pudo renombrar el agente",
+    "duplicate": "Duplicar",
+    "duplicateSuccess": "Agente duplicado correctamente",
+    "duplicateError": "No se pudo duplicar el agente",
+    "delete": "Eliminar",
+    "deleteAgent": "Eliminar agente",
+    "deleteDescription": "¿Seguro que quieres eliminar el agente \"{{name}}\"?",
+    "deleteWarning": "Esta acción no se puede deshacer. El agente se eliminará permanentemente.",
+    "deleteConfirm": "Eliminar",
+    "deleted": "Agente eliminado correctamente",
+    "deleteError": "No se pudo eliminar el agente",
+    "move": "Mover",
+    "moveAgent": "Mover agente",
+    "moveDescription": "Selecciona el proyecto al que mover el agente",
+    "moveProjectLabel": "Proyecto",
+    "moveProjectPlaceholder": "Seleccionar proyecto",
+    "moveSuccess": "Agente movido correctamente",
+    "moveError": "No se pudo mover el agente",
+    "moveConfirm": "Mover"
+  },
+  "publishSuccess": {
+    "title": "Agente publicado",
+    "version": "Versión v{{version}}",
+    "workflowIdLabel": "Workflow ID",
+    "apiKeyLabel": "Clave API",
+    "apiKeyAutoCreated": "Hemos creado una clave API para esta integración — guárdala ahora, no se mostrará de nuevo.",
+    "apiKeyHint": "No podemos mostrar las claves existentes. Usa una que ya tengas o crea una nueva.",
+    "apiKeyCreate": "Crear clave de integración",
+    "apiKeyCreating": "Creando…",
+    "apiKeyCreateError": "No se pudo crear la clave API",
+    "examplesLabel": "Ejemplos de integración",
+    "supportPrompt": "¿Tienes preguntas? Escríbenos:",
+    "copySuccess": "Copiado",
+    "close": "Listo"
+  },
+  "clientSessions": {
+    "title": "Sesiones de clientes",
+    "subtitle": "Gestiona los datos de los clientes y el historial de sesiones",
+    "noSessions": "Aún no hay sesiones de clientes",
+    "clientId": "Client ID",
+    "lastActivity": "Última actividad",
+    "executions": "Ejecuciones",
+    "credits": "Créditos",
+    "status": "Estado",
+    "active": "Activa",
+    "inactive": "Inactiva",
+    "never": "Nunca",
+    "onlyActive": "Solo activas",
+    "showTestSessions": "Mostrar sesiones de prueba",
+    "searchPlaceholder": "Buscar por Client ID...",
+    "deactivate": "Desactivar",
+    "deactivateConfirm": "¿Desactivar la sesión de cliente?",
+    "deactivateWarning": "Esto marcará la sesión de cliente como inactiva. Los datos de la sesión se conservarán.",
+    "deactivateSuccess": "Sesión de cliente desactivada",
+    "deactivateError": "No se pudo desactivar la sesión de cliente",
+    "details": "Detalles de la sesión de cliente",
+    "information": "Información",
+    "createdAt": "Creada",
+    "updatedAt": "Actualizada",
+    "projectState": "Estado del proyecto",
+    "metadata": "Metadatos",
+    "editMetadata": "Editar metadatos",
+    "editMetadataDescription": "Edita los metadatos como JSON",
+    "metadataUpdated": "Metadatos actualizados correctamente",
+    "updateError": "No se pudieron actualizar los metadatos",
+    "invalidJson": "Formato JSON no válido",
+    "noExecutions": "No hay ejecuciones para este cliente",
+    "noChatSessions": "No hay sesiones de chat para este cliente",
+    "tabs": {
+      "overview": "Resumen",
+      "state": "Estado",
+      "metadata": "Metadatos",
+      "executions": "Ejecuciones",
+      "chatSessions": "Sesiones de chat"
+    }
+  },
+  "projectSettings": {
+    "title": "Configuración del proyecto",
+    "subtitle": "Gestiona la configuración del proyecto y el esquema de estado",
+    "projectInfo": "Información del proyecto",
+    "projectInfoDescription": "Información básica sobre el proyecto",
+    "stateSchema": "Variables del proyecto",
+    "stateSchemaDescription": "Almacena de forma segura claves API, secretos y el estado de los clientes. Pasa client_id para acceder a los datos compartidos en todos los agentes del proyecto.",
+    "addVariable": "Añadir variable",
+    "variableName": "Nombre de la variable",
+    "variableType": "Tipo",
+    "defaultValue": "Valor por defecto",
+    "noVariables": "No hay variables del proyecto definidas",
+    "noVariablesDescription": "Crea variables para almacenar claves API, secretos y el estado de los clientes. Usa client_id para compartir datos entre agentes.",
+    "addVariableDescription": "Crear una nueva variable del proyecto",
+    "nameRequired": "El nombre de la variable es obligatorio",
+    "duplicateName": "Ya existe una variable con este nombre",
+    "variableAdded": "Variable añadida correctamente",
+    "addError": "No se pudo añadir la variable",
+    "deleteVariable": "¿Eliminar la variable?",
+    "deleteVariableWarning": "¿Seguro que quieres eliminar esta variable? Esto puede afectar a los flujos de trabajo que la usan.",
+    "variableDeleted": "Variable eliminada correctamente",
+    "deleteError": "No se pudo eliminar la variable"
+  },
+  "onboarding": {
+    "progress": "{{current}} de {{total}}",
+    "steps": {
+      "sidebar": {
+        "title": "Tu constructor",
+        "description": "Arrastra bloques al lienzo para construir la lógica de tu agente. Empieza con un nodo de agente — se encarga de la comunicación con el LLM"
+      },
+      "agentNode": {
+        "title": "Agente de IA — el corazón de tu flujo de trabajo",
+        "description": "Arrastra este bloque al lienzo — se convertirá en el cerebro de tu agente. Usa un LLM para entender las solicitudes y generar respuestas. Funciona desde el primer momento con nuestras claves del sistema — ¡solo empieza a probar!"
+      },
+      "debug": {
+        "title": "Prueba sobre la marcha",
+        "description": "Pulsa Play y prueba tu agente ahora mismo. Ya tienes créditos iniciales — envía mensajes y observa cómo el agente piensa y responde en cada paso"
+      },
+      "credits": {
+        "title": "Créditos y ahorro",
+        "description": "Cada ejecución de un agente consume créditos de tu saldo. ¿Quieres gastar menos? Conecta tus propias claves API de OpenAI, DeepSeek u otros proveedores — entonces solo 1 crédito por solicitud en lugar del costo de la llamada al LLM. Disponible en los planes PRO y BUSINESS"
+      },
+      "publish": {
+        "title": "¿Listo para producción?",
+        "description": "Cuando tu agente esté listo — publícalo. Después podrás llamarlo por API desde cualquier aplicación"
+      },
+      "final": {
+        "title": "¡Genial! Vamos a probarlo",
+        "description": "El chat de depuración se abrirá automáticamente. Envía un mensaje y ve a tu agente en acción. ¡Ya tienes créditos iniciales!",
+        "telegramButton": "Unirse a Discord",
+        "startButton": "Empezar a construir"
+      }
+    }
+  },
+  "billing": {
+    "unlimited": "Ilimitado",
+    "upgrade": "Mejorar",
+    "upgradePlan": "Mejorar plan",
+    "upgradeToPlan": "Pasar a {{plan}}",
+    "availableInPlan": "Disponible en {{plan}}",
+    "viewPlans": "Ver planes",
+    "highUsage": "Tienes un uso elevado de recursos",
+    "criticalUsage": "Has alcanzado un nivel crítico de uso",
+    "nextReset": "Los límites se restablecerán el {{date}}",
+    "section": {
+      "title": "Facturación y uso",
+      "subtitle": "Gestiona tu plan de facturación y controla el uso de recursos"
+    },
+    "usage": {
+      "agents": "Agentes",
+      "credits": "Créditos"
+    },
+    "pricing": {
+      "title": "Elige tu plan",
+      "subtitle": "Selecciona el plan que se ajuste a las necesidades de tu proyecto",
+      "popular": "Popular",
+      "perMonth": "mes",
+      "currentPlan": "Plan actual",
+      "getStarted": "Empieza gratis",
+      "contactSales": "Contáctanos",
+      "subscribe": "Suscribirse",
+      "business": {
+        "price": "Bajo consulta",
+        "description": "Condiciones individuales para grandes empresas",
+        "features": {
+          "consulting": "Consultoría experta y auditoría de procesos",
+          "integration": "Integración llave en mano y soporte de implementación",
+          "sla": "SLA personal y gerente dedicado",
+          "onpremise": "Opción de despliegue On-Premise"
+        }
+      },
+      "agents_one": "{{count}} agente",
+      "agents_other": "{{count}} agentes",
+      "unlimitedAgents": "Agentes ilimitados",
+      "agentsDesc": "Crea agentes de IA",
+      "creditsPerMonth": "créditos/mes",
+      "creditsDesc": "Úsalos para ejecutar agentes",
+      "rpmLimit_one": "{{count}} solicitud/min",
+      "rpmLimit_other": "{{count}} solicitudes/min",
+      "rpmDesc": "Tasa máxima de solicitudes a la API",
+      "unlimitedRequests": "Solicitudes ilimitadas con tus claves",
+      "unlimitedRequestsDesc": "0 créditos al usar tus propias claves API",
+      "ownApiKeys": "Claves API propias",
+      "ownApiKeysDesc": "Usa tus propias claves de proveedores de LLM",
+      "projectVariables": "Variables del proyecto",
+      "projectVariablesDesc": "Almacena secretos y el estado de los clientes con client_id",
+      "support": {
+        "community": "Soporte de la comunidad",
+        "email_24h": "Soporte por correo (24 h)",
+        "priority_4h_slack": "Soporte prioritario (4 h) + Slack"
+      },
+      "supportDesc": {
+        "community": "Ayuda a través del foro de la comunidad",
+        "email_24h": "Respuesta en un plazo de 24 horas",
+        "priority_4h_slack": "Respuesta rápida y canal directo"
+      },
+      "allPlansInclude": "Todos los planes incluyen:",
+      "commonFeatures": {
+        "allProviders": "Todos los proveedores de IA",
+        "visualBuilder": "Constructor visual",
+        "apiAccess": "Acceso a la API",
+        "sessionManagement": "Gestión de sesiones",
+        "logsMonitoring": "Registros y monitoreo"
+      },
+      "note": "Contáctanos para pasar a un plan de pago u obtener una solución empresarial"
+    },
+    "features": {
+      "projectVariables": {
+        "name": "Variables del proyecto",
+        "description": "Almacena claves API, secretos y el estado de los clientes. Pasa client_id — y todos los agentes acceden a los datos compartidos sin perder el contexto entre conversaciones."
+      }
+    },
+    "errors": {
+      "limitReached": "Límite de uso alcanzado",
+      "agentsLimitReached": "¡Hora de escalar! 🚀",
+      "agentsLimitReachedHint": "Has alcanzado el límite de agentes de tu plan actual. Pasa a PRO o BUSINESS — obtén más agentes, solicitudes ilimitadas y variables del proyecto para escenarios complejos.",
+      "creditsLimitReached": "Sin créditos 💳",
+      "creditsInsufficient": "Créditos insuficientes para ejecutar",
+      "creditsInsfficientHint": "Conecta tus propias claves API (plan PRO+) y paga solo 1 crédito por solicitud. O pasa a un plan con más créditos.",
+      "featureNotAvailable": "Esta función no está disponible en tu plan actual",
+      "rateLimitExceeded": "Límite de solicitudes excedido",
+      "rateLimitHint": "Has excedido el límite de {{rpm}} solicitudes por minuto. Reduce la frecuencia de las solicitudes o mejora tu plan."
+    },
+    "limitWarning": {
+      "warning": {
+        "agents": {
+          "title": "Pronto necesitarás más agentes",
+          "description": "Usados {{current}} de {{limit}} agentes ({{percentage}}%). Considera mejorar tu plan para escalar tus proyectos."
+        },
+        "credits": {
+          "title": "Los créditos se están agotando",
+          "description": "Quedan {{current}} de {{limit}} créditos ({{percentage}}%). Conecta tus propias claves API o pasa a un plan con más créditos."
+        }
+      },
+      "critical": {
+        "agents": {
+          "title": "¡Hora de mejorar el plan! 🚀",
+          "description": "Usados {{current}} de {{limit}} agentes ({{percentage}}%). Pasa a PRO o BUSINESS ahora para seguir construyendo."
+        },
+        "credits": {
+          "title": "¡Casi sin créditos! 💳",
+          "description": "Quedan {{current}} de {{limit}} créditos ({{percentage}}%). Mejora tu plan o conecta claves API para ahorrar costos."
+        }
+      }
+    },
+    "credits": {
+      "balance": "Saldo de créditos",
+      "current": "Saldo actual",
+      "used": "Usados",
+      "remaining": "Restantes",
+      "nextRefill": "Próxima recarga",
+      "refillIn": "Recarga en",
+      "dateUnknown": "Fecha desconocida",
+      "transactions": "Historial de transacciones",
+      "totalTransactions": "Total de transacciones",
+      "noTransactions": "Sin transacciones",
+      "viewAll": "Ver todas",
+      "transactionTypes": {
+        "plan_grant": "Asignación del plan",
+        "llm_usage": "Uso de LLM",
+        "request_fee": "Tarifa por solicitud",
+        "manual_topup": "Recarga manual",
+        "refund": "Reembolso"
+      },
+      "filters": {
+        "all": "Todos los tipos",
+        "type": "Tipo de transacción",
+        "period": "Período"
+      }
+    },
+    "systemKeys": {
+      "title": "Claves API del sistema",
+      "description": "Se usan las claves del sistema de los proveedores de LLM",
+      "upgradeMessage": "Las claves API propias están disponibles en los planes STARTER, PRO y BUSINESS",
+      "benefit": "Al usar tus propias claves, no se descuentan créditos por las solicitudes"
+    },
+    "payments": {
+      "confirmDialog": {
+        "title": "Suscribirse al plan",
+        "subtitle": "Estás pasando al plan {{plan}}",
+        "price": "Precio",
+        "autoRenewal": "Habilitar tarjeta para renovación automática",
+        "autoRenewalHint": "El dinero se cobrará automáticamente cada mes",
+        "cancel": "Cancelar",
+        "submit": "Proceder al pago",
+        "loading": "Creando el pago...",
+        "error": "No se pudo crear el pago. Inténtalo de nuevo."
+      },
+      "successPage": {
+        "checking": "Comprobando el estado del pago...",
+        "checkingHint": "Esto tomará unos segundos",
+        "success": "¡Suscripción activada!",
+        "successHint": "Ahora tienes acceso a todas las funciones del plan {{plan}}",
+        "goToAgents": "Ir a los agentes",
+        "error": "El pago falló",
+        "errorHint": "Inténtalo de nuevo o contacta con soporte",
+        "retry": "Intentar de nuevo",
+        "timeout": "No se pudo verificar el estado",
+        "timeoutHint": "Si el dinero fue cobrado, el plan se activará automáticamente"
+      }
+    }
+  },
+  "variableForm": {
+    "name": "Nombre",
+    "namePlaceholder": "Introduce el nombre de la variable",
+    "nameRequired": "El nombre de la variable no puede estar vacío",
+    "duplicateName": "Ya existe una variable con este nombre",
+    "defaultValue": "Valor por defecto",
+    "optional": "(opcional)",
+    "stringPlaceholder": "Introduce un valor",
+    "numberPlaceholder": "Introduce un número",
+    "booleanPlaceholder": "Selecciona un valor",
+    "projectVariable": "Variable del proyecto",
+    "projectVariableDescription": "Disponible en todos los flujos de trabajo del proyecto",
+    "projectVariableUpgradeRequired": "Pasa al plan Pro para usar variables del proyecto",
+    "objectPlaceholder": "Introduce un objeto JSON, p. ej. {\"key\": \"value\"}",
+    "invalidJson": "Formato JSON no válido",
+    "objectMustBeObject": "El valor debe ser un objeto JSON",
+    "editObjectValue": "Editar",
+    "objectEmpty": "Objeto vacío",
+    "objectSummary": "{{count}} claves"
+  },
+  "objectValueEditor": {
+    "title": "Valor por defecto",
+    "description": "Define el valor del objeto — mediante el constructor o JSON.",
+    "tabConstructor": "Constructor",
+    "tabJson": "JSON",
+    "addKey": "Añadir clave",
+    "keyPlaceholder": "clave",
+    "valuePlaceholder": "valor",
+    "emptyObject": "Vacío. Añade tu primera clave.",
+    "invalidJson": "JSON no válido",
+    "mustBeObject": "El valor debe ser un objeto"
+  },
+  "nodeTemplates": {
+    "templates": "Plantillas",
+    "saveAsTemplate": "Guardar como plantilla",
+    "edit": "Editar",
+    "duplicate": "Duplicar",
+    "modal": {
+      "title": "Guardar como plantilla",
+      "description": "Crea una plantilla reutilizable a partir de este nodo",
+      "name": "Nombre",
+      "namePlaceholder": "Mi plantilla",
+      "nameRequired": "El nombre es obligatorio",
+      "nameMaxLength": "El nombre no debe superar los 255 caracteres",
+      "templateDescription": "Descripción",
+      "descriptionPlaceholder": "Descripción de la plantilla (opcional)",
+      "descriptionMaxLength": "La descripción no debe superar los 1000 caracteres"
+    },
+    "editModal": {
+      "title": "Editar plantilla",
+      "description": "Cambia el nombre y la descripción de la plantilla"
+    },
+    "duplicateModal": {
+      "title": "Duplicar plantilla",
+      "description": "Selecciona el proyecto al que copiar la plantilla",
+      "selectProject": "Seleccionar proyecto",
+      "noOtherProjects": "No hay otros proyectos disponibles para copiar"
+    },
+    "createSuccess": "Plantilla creada correctamente",
+    "createError": "No se pudo crear la plantilla",
+    "updateSuccess": "Plantilla actualizada",
+    "updateError": "No se pudo actualizar la plantilla",
+    "duplicateSuccess": "Plantilla duplicada",
+    "duplicateError": "No se pudo duplicar la plantilla",
+    "deleteSuccess": "Plantilla eliminada",
+    "deleteError": "No se pudo eliminar la plantilla",
+    "deleteConfirm": "¿Eliminar la plantilla?",
+    "deleteWarning": "¿Seguro que quieres eliminar \"{{name}}\"?",
+    "noTemplates": "No hay plantillas guardadas",
+    "noTemplatesDescription": "Guarda un nodo como plantilla para reutilizarlo rápidamente"
+  },
+  "knowledgeBases": {
+    "title": "Bases de conocimiento",
+    "subtitle": "Gestiona las bases de conocimiento de tus agentes",
+    "create": "Crear base de conocimiento",
+    "empty": "No hay bases de conocimiento",
+    "emptyDescription": "Crea una base de conocimiento para que los agentes puedan usar tus documentos",
+    "columns": {
+      "name": "Nombre",
+      "description": "Descripción",
+      "documents": "Documentos",
+      "characters": "Caracteres",
+      "createdAt": "Creada",
+      "actions": "Acciones"
+    },
+    "createModal": {
+      "title": "Crear base de conocimiento",
+      "editTitle": "Editar base de conocimiento",
+      "nameLabel": "Nombre",
+      "namePlaceholder": "Introduce el nombre de la base de conocimiento",
+      "descriptionLabel": "Descripción",
+      "descriptionPlaceholder": "Descripción opcional",
+      "nameRequired": "El nombre es obligatorio"
+    },
+    "deleteDialog": {
+      "title": "Eliminar base de conocimiento",
+      "description": "¿Seguro que quieres eliminar la base de conocimiento \"{{name}}\"? Todos los documentos se eliminarán permanentemente."
+    },
+    "createSuccess": "Base de conocimiento creada",
+    "createError": "No se pudo crear la base de conocimiento",
+    "updateSuccess": "Base de conocimiento actualizada",
+    "updateError": "No se pudo actualizar la base de conocimiento",
+    "deleteSuccess": "Base de conocimiento eliminada",
+    "deleteError": "No se pudo eliminar la base de conocimiento"
+  },
+  "knowledgeBaseDetails": {
+    "backToList": "Bases de conocimiento",
+    "usage": "{{used}} / {{max}} caracteres usados",
+    "addText": "Añadir texto",
+    "uploadPDF": "Subir PDF",
+    "documentsTitle": "Documentos",
+    "empty": "No hay documentos",
+    "emptyDescription": "Añade texto o sube un PDF para llenar la base de conocimiento",
+    "columns": {
+      "name": "Nombre",
+      "type": "Tipo",
+      "characters": "Caracteres",
+      "createdAt": "Añadido",
+      "actions": "Acciones"
+    },
+    "docType": {
+      "text": "Texto",
+      "pdf": "PDF"
+    },
+    "addTextModal": {
+      "title": "Añadir texto",
+      "nameLabel": "Nombre del documento",
+      "namePlaceholder": "Introduce el nombre del documento",
+      "contentLabel": "Contenido",
+      "contentPlaceholder": "Pega tu texto aquí...",
+      "nameRequired": "El nombre es obligatorio",
+      "contentRequired": "El contenido es obligatorio"
+    },
+    "uploadPDFModal": {
+      "title": "Subir PDF",
+      "nameLabel": "Nombre del documento",
+      "namePlaceholder": "Introduce el nombre del documento",
+      "fileLabel": "Archivo PDF",
+      "filePlaceholder": "Selecciona un archivo PDF",
+      "uploading": "Subiendo...",
+      "nameRequired": "El nombre es obligatorio",
+      "fileRequired": "Por favor, selecciona un archivo PDF"
+    },
+    "viewDocumentModal": {
+      "title": "Contenido del documento"
+    },
+    "deleteDialog": {
+      "title": "Eliminar documento",
+      "description": "¿Seguro que quieres eliminar el documento \"{{name}}\"?"
+    },
+    "addSuccess": "Documento añadido",
+    "addError": "No se pudo añadir el documento",
+    "uploadSuccess": "PDF subido",
+    "uploadError": "No se pudo subir el PDF",
+    "deleteSuccess": "Documento eliminado",
+    "deleteError": "No se pudo eliminar el documento",
+    "errorDuplicate": "Ya existe un documento con este contenido",
+    "errorNoText": "El PDF no contiene texto (documento escaneado sin OCR)"
+  },
+  "schemaBuilder": {
+    "title": "Salida estructurada (JSON)",
+    "description": "El modelo generará un objeto JSON que coincida con este esquema",
+    "simpleMode": "Visual",
+    "advancedMode": "JSON",
+    "schemaName": "Nombre",
+    "properties": "Propiedades",
+    "noProperties": "No hay propiedades. Añade la primera propiedad.",
+    "addProperty": "Añadir propiedad",
+    "jsonSyntaxError": "Sintaxis JSON no válida",
+    "jsonMustBeObject": "El esquema debe ser un objeto JSON"
+  },
+  "meta": {
+    "title": "Assemblix - Constructor visual de agentes de IA",
+    "description": "Crea agentes de IA inteligentes sin código con el constructor visual de Assemblix. Automatiza procesos de negocio, crea chatbots y flujos de trabajo.",
+    "keywords": "agentes de IA, constructor de agentes, editor visual, constructor de flujos de trabajo, automatización, chatbots, inteligencia artificial, no-code, low-code, Assemblix"
+  }
+}

--- a/assemblix-app-web/src/shared/i18n/locales/ru.json
+++ b/assemblix-app-web/src/shared/i18n/locales/ru.json
@@ -1,0 +1,1349 @@
+{
+  "footer": {
+    "terms": "Условия использования",
+    "privacy": "Политика конфиденциальности",
+    "refund": "Политика возврата",
+    "contact": "Связаться с нами"
+  },
+  "notFoundPage": {
+    "title": "Похоже, вы зашли в тупик",
+    "subtitle": "Этой страницы не существует — путь закончился ошибкой 404. Давайте вернем вас на маршрут.",
+    "home": "На главную",
+    "back": "Назад"
+  },
+  "common": {
+    "save": "Сохранить",
+    "update": "Обновить",
+    "cancel": "Отмена",
+    "delete": "Удалить",
+    "create": "Создать",
+    "edit": "Редактировать",
+    "close": "Закрыть",
+    "confirm": "Подтвердить",
+    "loading": "Загрузка...",
+    "yes": "Да",
+    "no": "Нет",
+    "back": "Назад",
+    "next": "Далее",
+    "search": "Поиск",
+    "actions": "Действия",
+    "status": "Статус",
+    "name": "Название",
+    "type": "Тип",
+    "value": "Значение",
+    "description": "Описание",
+    "createdAt": "Создано",
+    "updatedAt": "Обновлено",
+    "optional": "необязательно",
+    "required": "обязательно",
+    "total": "Всего",
+    "showMore": "Показать больше",
+    "showLess": "Свернуть",
+    "or": "или",
+    "locale": "ru"
+  },
+  "auth": {
+    "login": "Вход",
+    "register": "Регистрация",
+    "logout": "Выйти",
+    "email": "Email",
+    "password": "Пароль",
+    "confirmPassword": "Подтвердите пароль",
+    "fullName": "Полное имя",
+    "name": "Имя",
+    "forgotPassword": "Забыли пароль?",
+    "signIn": "Войти",
+    "signUp": "Зарегистрироваться",
+    "createAccount": "Создать аккаунт",
+    "enterCredentials": "Введите свои данные для входа",
+    "registerDescription": "Создайте аккаунт, чтобы начать работу с Assemblix",
+    "user": "Пользователь",
+    "emailValidation": "Пожалуйста, введите корректный email.",
+    "emailPlaceholder": "your@email.com",
+    "namePlaceholder": "Ваше имя",
+    "passwordMinLength": "Пароль должен содержать не менее 3 символов.",
+    "passwordsNotMatch": "Пароли не совпадают",
+    "nameMinLength": "Имя должно содержать не менее 2 символов.",
+    "loginError": "Ошибка входа",
+    "registerError": "Ошибка регистрации",
+    "registerErrorDescription": "Попробуйте позже или используйте другой email",
+    "invalidCredentials": "Неверный email или пароль",
+    "noAccount": "Нет аккаунта?",
+    "hasAccount": "Уже есть аккаунт?",
+    "oauth": {
+      "continueWithGoogle": "Продолжить с Google",
+      "continueWithGitHub": "Продолжить с GitHub",
+      "continueWithYandex": "Продолжить с Яндексом",
+      "googleError": "Ошибка входа через Google",
+      "googleErrorDescription": "Не удалось войти через Google. Попробуйте еще раз.",
+      "githubError": "Ошибка входа через GitHub",
+      "githubErrorDescription": "Не удалось войти через GitHub. Попробуйте еще раз.",
+      "githubProcessing": "Завершаем вход через GitHub...",
+      "githubStateMismatch": "Неверный параметр state — войдите еще раз",
+      "emailAlreadyRegistered": "Email уже зарегистрирован",
+      "emailAlreadyRegisteredDescription": "Этот email уже зарегистрирован с паролем. Войдите через форму входа или сбросьте пароль.",
+      "emailNotVerified": "Email не подтвержден",
+      "emailNotVerifiedDescription": "Пожалуйста, подтвердите email в вашем аккаунте Google.",
+      "cancelled": "Вход отменен пользователем"
+    }
+  },
+  "header": {
+    "appName": "Assemblix",
+    "lightTheme": "Светлая тема",
+    "darkTheme": "Темная тема",
+    "language": "Язык",
+    "help": "Помощь",
+    "organizationSettings": "Настройки организации"
+  },
+  "sidebar": {
+    "agents": "Агенты",
+    "agentSessions": "Вызовы агентов",
+    "apiKeys": "API-ключи",
+    "knowledgeBases": "Базы знаний",
+    "organization": "Организация",
+    "credentials": "Учетные данные",
+    "clientSessions": "Клиентские сессии",
+    "projectSettings": "Настройки проекта",
+    "settings": "Настройки",
+    "community": "Сообщество",
+    "sections": {
+      "creation": "Создание",
+      "monitoring": "Мониторинг"
+    }
+  },
+  "home": {
+    "title": "Создайте своего агента",
+    "subtitle": "Создавайте AI-агентов и управляйте ими в визуальном редакторе",
+    "createAgent": "Создать нового агента"
+  },
+  "sessions": {
+    "title": "Вызовы агентов",
+    "subtitle": "История чатов и запусков ваших агентов",
+    "tabs": {
+      "chats": "Чаты",
+      "executions": "Запуски"
+    },
+    "showTestSessions": "Показывать тестовые сессии"
+  },
+  "agents": {
+    "title": "Агенты",
+    "createAgent": "Создать агента",
+    "noAgents": "У вас пока нет агентов",
+    "createFirstAgent": "Создайте первого агента, чтобы начать",
+    "lastModified": "Последнее изменение",
+    "published": "Опубликован",
+    "draft": "Черновик",
+    "selectProject": "Выберите проект",
+    "createError": "Ошибка создания агента",
+    "publishSuccess": "Агент успешно опубликован",
+    "publishError": "Ошибка публикации агента",
+    "deleteSuccess": "Агент удален",
+    "deleteError": "Ошибка удаления агента",
+    "renameSuccess": "Агент переименован",
+    "renameError": "Ошибка переименования агента"
+  },
+  "workflow": {
+    "nodes": {
+      "start": "Старт",
+      "agent": "Агент",
+      "sticker": "Стикер",
+      "condition": "Условие",
+      "setVariable": "Установить переменную",
+      "end": "Конец",
+      "httpRequest": "HTTP-запрос",
+      "newElement": "Новый элемент"
+    },
+    "nodeDefaults": {
+      "agentName": "Новый агент",
+      "endName": "Успех"
+    },
+    "nodeDescriptions": {
+      "start": "Точка входа воркфлоу",
+      "agent": "Вызов LLM с параметрами",
+      "sticker": "Добавить стикер",
+      "condition": "Проверка логического условия",
+      "setVariable": "Присвоить значение переменной",
+      "end": "Завершение выполнения воркфлоу",
+      "httpRequest": "HTTP-запрос к внешнему API"
+    },
+    "categories": {
+      "main": "Основные",
+      "logic": "Логика",
+      "data": "Данные",
+      "integrations": "Интеграции"
+    },
+    "sidebar": {
+      "selectNodeType": "Выберите тип узла",
+      "clickToSelect": "Нажмите на нужный элемент ниже"
+    },
+    "stateSidebar": {
+      "title": "Управление состоянием",
+      "agentState": "Состояние агента",
+      "projectState": "Состояние проекта",
+      "live": "LIVE",
+      "noVariables": "Нет переменных состояния",
+      "readOnlyHint": "Воркфлоу выполняется — редактирование отключено"
+    },
+    "header": {
+      "debug": "Отладка",
+      "publish": "Опубликовать",
+      "published": "Опубликован",
+      "debugMode": "Режим отладки",
+      "exitDebug": "Выйти из отладки",
+      "editMode": "Режим редактирования",
+      "workMode": "Рабочий режим",
+      "publishError": "Не удалось опубликовать воркфлоу",
+      "agentCalls": "Вызовы агентов"
+    },
+    "agentCalls": {
+      "title": "Вызовы агентов",
+      "executions": "Запуски",
+      "chats": "Чаты",
+      "noExecutions": "У этого агента нет запусков",
+      "noChats": "У этого агента нет чатов",
+      "selectChat": "Выберите чат для просмотра"
+    },
+    "bulkInstructions": {
+      "title": "Инструкции агентов",
+      "openTooltip": "Редактировать инструкции всех агентов",
+      "emptyTooltip": "В этом воркфлоу нет узлов-агентов",
+      "searchPlaceholder": "Поиск агента...",
+      "unnamedAgent": "Агент #{{index}}",
+      "noAgentsFound": "Агенты не найдены",
+      "selectAgentHint": "Выберите агента слева, чтобы редактировать его инструкции",
+      "emptyState": "В этом воркфлоу пока нет узлов-агентов. Добавьте агента на холст, чтобы начать редактировать инструкции.",
+      "addInstruction": "Добавить инструкцию"
+    },
+    "rename": {
+      "title": "Переименовать агента",
+      "namePlaceholder": "Название агента",
+      "nameRequired": "Название обязательно",
+      "nameMinLength": "Название должно содержать не менее 3 символов"
+    },
+    "publish": {
+      "title": "Агент опубликован",
+      "description": "Ваш агент успешно опубликован и готов к использованию",
+      "close": "Закрыть"
+    },
+    "versions": {
+      "draft": "Черновик",
+      "version": "Версия",
+      "current": "Текущая"
+    },
+    "editor": {
+      "nodeEditor": "Редактор узла",
+      "unknownNodeType": "Неизвестный тип узла",
+      "loadingNodeTypes": "Загрузка типов узлов…",
+      "data": "Данные"
+    },
+    "details": {
+      "loadingError": "Ошибка загрузки",
+      "loadingErrorDescription": "Не удалось загрузить данные агента. Возможно, он был удален или у вас нет доступа.",
+      "backToList": "К списку",
+      "versionLoadError": "Ошибка",
+      "versionLoadErrorDescription": "Не удалось загрузить версию"
+    },
+    "node": {
+      "agent": {
+        "warnings": {
+          "modelNotSelected": "Модель не выбрана"
+        }
+      }
+    }
+  },
+  "provider": {
+    "openai": "OpenAI",
+    "gemini": "Gemini",
+    "deepseek": "DeepSeek",
+    "temperature": "Температура",
+    "temperatureHelp": "Управляет случайностью ответов (0-2)"
+  },
+  "credentials": {
+    "title": "Управление учетными данными",
+    "subtitle": "Добавляйте и редактируйте API-ключи для использования в воркфлоу",
+    "addCredential": "Добавить учетные данные",
+    "addFirstCredential": "Добавить первые учетные данные",
+    "noCredentials": "У вас пока нет сохраненных учетных данных",
+    "type": "Тип",
+    "selectType": "Выберите тип",
+    "name": "Название",
+    "namePlaceholder": "Мой API-ключ",
+    "nameMinLength": "Название должно содержать не менее 3 символов",
+    "value": "Значение",
+    "newValue": "Новое значение (необязательно)",
+    "valuePlaceholder": "sk-...",
+    "newValuePlaceholder": "Введите новое значение или оставьте пустым",
+    "valueRequired": "Значение обязательно",
+    "createSuccess": "Учетные данные созданы",
+    "createError": "Не удалось создать учетные данные",
+    "updateSuccess": "Учетные данные обновлены",
+    "updateError": "Не удалось обновить учетные данные",
+    "deleteSuccess": "Учетные данные удалены",
+    "deleteError": "Не удалось удалить учетные данные",
+    "deleteConfirm": "Удалить учетные данные?",
+    "deleteWarning": "Вы уверены, что хотите удалить \"{{name}}\"? Это действие нельзя отменить.",
+    "untitled": "Без названия",
+    "selectCredentialType": "Пожалуйста, выберите тип учетных данных",
+    "select": {
+      "placeholder": "Выберите учетные данные",
+      "title": "Учетные данные",
+      "description": "Выберите учетные данные для использования",
+      "noKeys": "Нет доступных ключей. Добавьте первые учетные данные.",
+      "add": "Добавить учетные данные"
+    },
+    "systemToken": {
+      "name": "Системный токен Assemblix",
+      "description": "Используйте наши токены для быстрого старта. За использование LLM списываются кредиты."
+    }
+  },
+  "apiKeys": {
+    "title": "API-ключи",
+    "subtitle": "Управляйте API-ключами для аутентификации в вашем приложении",
+    "createKey": "Создать API-ключ",
+    "createFirstKey": "Создать первый ключ",
+    "noKeys": "У вас пока нет API-ключей",
+    "noKeysDescription": "Создайте первый API-ключ, чтобы начать работать с API",
+    "name": "Название",
+    "key": "Ключ",
+    "created": "Создан",
+    "lastUsed": "Последнее использование",
+    "requests": "Запросы",
+    "neverUsed": "Не использовался",
+    "totalKeys": "Всего ключей",
+    "createSuccess": "API-ключ успешно создан",
+    "createError": "Ошибка создания API-ключа",
+    "deleteSuccess": "API-ключ успешно удален",
+    "deleteError": "Ошибка удаления API-ключа",
+    "copySuccess": "Ключ скопирован в буфер обмена",
+    "copyError": "Не удалось скопировать ключ",
+    "copyKey": "Скопировать ключ",
+    "justNow": "только что",
+    "minutesAgo": "{{count}} мин. назад",
+    "hoursAgo": "{{count}} ч. назад",
+    "daysAgo": "{{count}} дн. назад",
+    "deleteConfirm": "Удалить API-ключ?",
+    "deleteWarning": "Вы уверены, что хотите удалить \"{{name}}\"? Ключ сразу перестанет работать, и это действие нельзя отменить.",
+    "enterKeyName": "Введите название ключа",
+    "selectProject": "Выберите проект",
+    "modal": {
+      "createTitle": "Создать API-ключ",
+      "createDescription": "Введите название нового API-ключа. Это поможет вам идентифицировать ключ позже.",
+      "saveTitle": "Сохраните ваш API-ключ",
+      "saveWarning": "Важно! Скопируйте и сохраните этот ключ в надежном месте.",
+      "saveDescription": "Он больше не будет показан. Если вы его потеряете, придется создать новый ключ.",
+      "yourKey": "Ваш API-ключ",
+      "namePlaceholder": "например, Production API Key",
+      "creating": "Создание...",
+      "done": "Готово, я сохранил ключ",
+      "useInHeader": "Используйте этот ключ в заголовке Authorization:"
+    },
+    "delete": {
+      "title": "Удалить API-ключ?",
+      "description": "Вы уверены, что хотите удалить ключ",
+      "warning": "Ключ сразу перестанет работать, и это действие нельзя отменить.",
+      "deleting": "Удаление..."
+    }
+  },
+  "chats": {
+    "title": "Чаты",
+    "noChats": "У вас пока нет чатов",
+    "noChatsDescription": "Чаты появятся здесь после их создания",
+    "agent": "Агент",
+    "messages": "сообщений",
+    "lastMessage": "Последнее сообщение",
+    "active": "Активен",
+    "inactive": "Неактивен",
+    "credits": "Кредиты:",
+    "infoBanner": {
+      "title": "📬 Здесь появятся чаты ваших агентов",
+      "description": "Когда вы запустите агента с параметром create_session: true, здесь появится чат-сессия с полной историей диалога и статистикой."
+    },
+    "rename": "Переименовать",
+    "delete": "Удалить",
+    "deleteTitle": "Удалить сессию",
+    "deleteDescription": "Сессия и все сообщения будут удалены навсегда. Это действие нельзя отменить.",
+    "renameLabel": "Название сессии",
+    "renamePlaceholder": "Введите название сессии...",
+    "cancel": "Отмена"
+  },
+  "chatDetails": {
+    "title": "Чат от",
+    "sendMessage": "Отправить сообщение",
+    "typePlaceholder": "Введите сообщение...",
+    "agent": "Агент",
+    "user": "Пользователь",
+    "notFound": "Чат не найден",
+    "noMessages": "В этом чате нет сообщений",
+    "goToExecution": "Перейти к запуску",
+    "credits": "кредитов"
+  },
+  "executions": {
+    "title": "Запуски",
+    "noExecutions": "У вас пока нет запусков",
+    "noExecutionsDescription": "Здесь появится история запусков агентов",
+    "agent": "Агент",
+    "status": "Статус",
+    "started": "Запущен",
+    "duration": "Длительность",
+    "steps": "Шаги:",
+    "credits": "Кредиты:",
+    "clientSession": "Клиентская сессия",
+    "filterByClientId": "Фильтр по Client ID...",
+    "statuses": {
+      "running": "Выполняется",
+      "completed": "Завершен",
+      "failed": "Ошибка",
+      "pending": "В очереди"
+    },
+    "infoBanner": {
+      "title": "🚀 Здесь появятся запуски ваших агентов",
+      "description": "Каждый запуск опубликованного агента создает запись в истории. Вы увидите детали выполнения, использованные токены, стоимость и результаты."
+    }
+  },
+  "executionViewer": {
+    "title": "Просмотр запуска",
+    "step": "Шаг",
+    "stepNumber": "Шаг №",
+    "input": "Входные данные",
+    "output": "Выходные данные",
+    "error": "Ошибка",
+    "errorMessage": "Сообщение об ошибке",
+    "errorExecution": "Ошибка выполнения",
+    "errorInNode": "Ошибка в узле:",
+    "logs": "Логи",
+    "backToExecutions": "К списку запусков",
+    "back": "Назад",
+    "duration": "Длительность",
+    "credits": "Кредиты",
+    "steps": "Шаги",
+    "executionFrom": "Запуск от",
+    "model": "Модель",
+    "stateBefore": "Состояние до",
+    "stateAfter": "Состояние после",
+    "celEvaluations": "CEL-вычисления",
+    "llmRequest": "Запрос к LLM",
+    "currentState": "Состояние",
+    "stateAfterStep": "Состояние после шага",
+    "stateChanges": "Изменения",
+    "fullState": "Полное состояние",
+    "noChanges": "Этот узел не изменил состояние",
+    "loadingError": "Ошибка загрузки",
+    "loadingErrorDescription": "Не удалось загрузить данные запуска. Возможно, он был удален или у вас нет доступа."
+  },
+  "organization": {
+    "title": "Настройки организации",
+    "subtitle": "Управление основными настройками и участниками организации",
+    "members": "Участники",
+    "membersCount_one": "участник",
+    "membersCount_few": "участника",
+    "membersCount_many": "участников",
+    "membersCount_other": "участника",
+    "projects": "Проекты",
+    "addMember": "Добавить участника",
+    "removeMember": "Удалить участника",
+    "email": "Email",
+    "role": "Роль",
+    "actions": "Действия",
+    "member": "Участник",
+    "joinedDate": "Дата присоединения",
+    "noMembers": "Нет участников",
+    "noMembersDescription": "Добавьте первого участника организации",
+    "noName": "Без имени",
+    "selectOrganization": "Выберите организацию",
+    "selectProject": "Выберите проект",
+    "createProject": "Создать проект",
+    "addOrganization": "Добавить организацию",
+    "addProject": "Добавить проект",
+    "createOrganization": "Создать организацию",
+    "organizationName": "Название организации",
+    "organizationNamePlaceholder": "например, Моя команда",
+    "projectName": "Название проекта",
+    "projectNamePlaceholder": "например, Production",
+    "enterOrganizationName": "Введите название организации",
+    "enterProjectName": "Введите название нового проекта",
+    "organizationCreated": "Организация создана",
+    "projectCreated": "Проект создан",
+    "organizationCreateError": "Не удалось создать организацию",
+    "projectCreateError": "Не удалось создать проект",
+    "creating": "Создание...",
+    "saving": "Сохранение...",
+    "enterName": "Введите название организации",
+    "enterProjectNameError": "Введите название проекта",
+    "selectOrganizationFirst": "Выберите организацию",
+    "nameNotChanged": "Название не изменилось",
+    "nameUpdated": "Название организации обновлено",
+    "nameUpdateError": "Ошибка обновления названия",
+    "onlyOwnerCanEdit": "Только владелец может изменить название организации",
+    "basicSettings": "Основные настройки",
+    "organizationInfo": "Информация об организации",
+    "roles": {
+      "owner": "Владелец",
+      "admin": "Администратор",
+      "member": "Участник"
+    },
+    "addMemberModal": {
+      "title": "Добавить участника",
+      "description": "Введите email пользователя, который уже зарегистрирован в системе.",
+      "emailPlaceholder": "user@example.com",
+      "selectRole": "Выберите роль",
+      "isOwner": "Владелец организации",
+      "isOwnerDescription": "Владельцы могут добавлять и удалять участников",
+      "addSuccess": "Участник успешно добавлен",
+      "addError": "Ошибка добавления участника",
+      "userNotFound": "Пользователь с таким email не найден",
+      "userAlreadyMember": "Пользователь уже является участником организации",
+      "noPermission": "Недостаточно прав для добавления участников",
+      "enterEmail": "Введите email участника",
+      "enterValidEmail": "Введите корректный email",
+      "adding": "Добавление..."
+    },
+    "removeMemberModal": {
+      "title": "Удалить участника?",
+      "description": "Вы уверены, что хотите удалить",
+      "fromOrganization": "из организации?",
+      "warning": "Участник потеряет доступ ко всем проектам и ресурсам организации. Это действие можно отменить, добавив участника снова.",
+      "removeSuccess": "Участник удален из организации",
+      "removeError": "Ошибка удаления участника",
+      "cannotRemoveOwner": "Нельзя удалить владельца организации",
+      "noPermission": "Недостаточно прав для удаления участников",
+      "deleting": "Удаление..."
+    }
+  },
+  "settings": {
+    "title": "Настройки",
+    "subtitle": "Цветовая палитра, используемая в системе",
+    "theme": "Тема",
+    "lightTheme": "Светлая",
+    "darkTheme": "Темная",
+    "systemTheme": "Системная",
+    "language": "Язык",
+    "tabs": {
+      "general": "Общие",
+      "apiKeys": "API-ключи",
+      "credentials": "Учетные данные",
+      "notifications": "Уведомления"
+    },
+    "colorCategories": {
+      "basic": "Основные цвета",
+      "accents": "Акценты",
+      "statuses": "Статусы",
+      "workflowNodes": "Узлы воркфлоу",
+      "borders": "Границы и элементы",
+      "sidebar": "Боковая панель"
+    }
+  },
+  "notifications": {
+    "title": "Уведомления",
+    "subtitle": "Каналы, которые получают оповещения о технических сбоях выполнения воркфлоу. Применяется ко всем воркфлоу проекта.",
+    "empty": "Каналы уведомлений пока не настроены",
+    "addFirst": "Добавить первый канал",
+    "add": "Добавить канал",
+    "untitled": "Без названия",
+    "disabled": "Отключен",
+    "enabled": "Канал включен",
+    "type": "Тип источника",
+    "name": "Название",
+    "namePlaceholder": "например, Prod alerts",
+    "botToken": "Токен бота",
+    "botTokenPlaceholder": "123456:ABC-DEF...",
+    "botTokenEditPlaceholder": "Оставьте пустым, чтобы сохранить текущий",
+    "botTokenRequired": "Токен бота обязателен",
+    "chatId": "Chat ID",
+    "chatIdPlaceholder": "-1001234567890",
+    "chatIdRequired": "Chat ID обязателен",
+    "test": "Тест",
+    "testSuccess": "Тестовое сообщение отправлено",
+    "testError": "Не удалось отправить тестовое сообщение",
+    "createSuccess": "Канал создан",
+    "createError": "Не удалось создать канал",
+    "updateSuccess": "Канал обновлен",
+    "updateError": "Не удалось обновить канал",
+    "deleteConfirm": "Удалить канал?",
+    "deleteWarning": "Канал \"{{name}}\" будет удален навсегда.",
+    "deleteSuccess": "Канал удален",
+    "deleteError": "Не удалось удалить канал"
+  },
+  "errors": {
+    "generic": "Произошла ошибка",
+    "networkError": "Ошибка сети",
+    "unauthorized": "Требуется авторизация",
+    "forbidden": "Доступ запрещен",
+    "notFound": "Не найдено",
+    "serverError": "Ошибка сервера"
+  },
+  "variables": {
+    "title": "Переменные",
+    "addVariable": "Добавить переменную",
+    "noVariables": "Нет доступных переменных",
+    "availableVariables": "Доступные переменные",
+    "state": "Состояние",
+    "input": "Входные данные"
+  },
+  "nodeForms": {
+    "start": {
+      "title": "Старт",
+      "firstPhrase": "Первая фраза",
+      "firstPhraseHint": "Приветствие ассистента, которое добавляется в историю первым сообщением при старте новой сессии.",
+      "firstPhrasePlaceholder": "Привет! Чем могу помочь?",
+      "inputVariables": "Входные переменные",
+      "projectVariables": "Переменные проекта",
+      "projectVariablesNote": "Эти переменные определены на уровне проекта и доступны во всех воркфлоу",
+      "stateVariables": "Переменные состояния",
+      "add": "Добавить",
+      "variableUpdateError": "Ошибка обновления переменной",
+      "variableAddError": "Ошибка добавления переменной",
+      "variableUpdated": "Переменная \"{{name}}\" обновлена",
+      "variableAdded": "Переменная \"{{name}}\" добавлена",
+      "variableDeleteError": "Ошибка удаления переменной",
+      "variableDeleted": "Переменная удалена"
+    },
+    "end": {
+      "title": "Конец",
+      "endpointPlaceholder": "например, Успех, Ошибка",
+      "isSessionEnd": "Завершить сессию",
+      "sessionEndDescription": "Сессия станет неактивной. Используйте как индикатор завершения диалога.",
+      "isError": "Бизнес-ошибка",
+      "isErrorDescription": "Пометить завершение как намеренный отказ агента (статус ERROR вместо COMPLETED)",
+      "errorMessage": "Сообщение об ошибке",
+      "errorMessagePlaceholder": "{{state.error_reason}}",
+      "advancedSettings": "Расширенные настройки",
+      "outputSource": "Источник ответа",
+      "outputModeLastAgent": "Последний агент",
+      "outputModeSpecificAgent": "Конкретный агент",
+      "outputModeCustom": "Фиксированное сообщение",
+      "selectAgent": "Выберите агента",
+      "agentLabel": "Агент",
+      "goToAgent": "Перейти к агенту",
+      "customMessage": "Сообщение",
+      "customMessagePlaceholder": "{{input.message}} или фиксированный текст",
+      "dataFiltering": "Фильтрация данных",
+      "stateFilter": "Переменные состояния",
+      "projectFilter": "Переменные проекта",
+      "filterAll": "Все",
+      "filterNone": "Не возвращать",
+      "filterSelected": "Выбранные",
+      "selectVariables": "Выберите переменные",
+      "noAgents": "Нет доступных агентов",
+      "properties": "Свойства (JSON)",
+      "propertiesPlaceholder": "{\n  \"status\": \"success\",\n  \"message\": \"Workflow completed\"\n}",
+      "invalidJSON": "⚠️ Некорректный JSON. Должен быть объект.",
+      "propertiesHelp": "Введите JSON-объект с дополнительными свойствами для узла завершения",
+      "preview": "Предпросмотр:"
+    },
+    "sticker": {
+      "title": "Стикер",
+      "text": "Текст стикера",
+      "placeholder": "Напишите заметку..."
+    },
+    "condition": {
+      "title": "Условие",
+      "conditions": "Условия",
+      "expression": "Выражение {{number}}",
+      "expressionPlaceholder": "state.counter > 10",
+      "branchName": "Название ветки",
+      "branchPlaceholder": "например, high_count",
+      "add": "Добавить условие",
+      "defaultBranch": "По умолчанию",
+      "defaultBranchPlaceholder": "default",
+      "namePlaceholder": "Введите название условия"
+    },
+    "setVariable": {
+      "title": "Установить переменную",
+      "updates": "Обновления переменных",
+      "variable": "Переменная {{number}}",
+      "selectVariable": "Выберите переменную",
+      "value": "Значение",
+      "valuePlaceholder": "state.counter + 1",
+      "add": "Добавить обновление",
+      "advancedUsage": "Расширенное использование",
+      "merges": "Умное слияние",
+      "merge": "Слияние {{number}}",
+      "addMerge": "Добавить слияние",
+      "mergeSource": "Источник",
+      "mergeSourcePlaceholder": "input.parsed_message",
+      "mergeTargetKey": "Переменная состояния",
+      "mergeTargetKeyAll": "Все состояние",
+      "mergeTarget": "Назначение",
+      "mergeTargetState": "Состояние",
+      "mergeTargetProject": "Проект",
+      "mergeOperation": "Операция",
+      "mergeOperationAdd": "Сложить (+)",
+      "mergeOperationSubtract": "Вычесть (−)",
+      "mergeOperationOverwrite": "Перезаписать (=)"
+    },
+    "agent": {
+      "title": "Агент",
+      "name": "Название",
+      "namePlaceholder": "Введите название агента",
+      "provider": "Провайдер",
+      "selectProvider": "Выберите провайдера",
+      "model": "Модель",
+      "modelPlaceholder": "gpt-4, gemini-pro и т.д.",
+      "selectModel": "Выберите модель",
+      "advancedSettings": "Расширенные настройки",
+      "maxRetries": "Повторы при временных ошибках",
+      "maxRetriesPlaceholder": "По умолчанию",
+      "timeout": "Таймаут, секунды",
+      "timeoutPlaceholder": "По умолчанию",
+      "enforceTimeoutOnLast": "Жесткий таймаут для последней модели",
+      "enforceTimeoutOnLastTooltip": "Если включено, таймаут на вызов применяется и к последней модели в цепочке, чтобы ни один провайдер не мог подвесить запуск. Если выключено, последняя модель может работать вплоть до общего таймаута как крайний вариант.",
+      "fallbackModels": "Резервные модели",
+      "fallbackModelsHint": "Используются по порядку, когда основная модель раз за разом возвращает временные ошибки (лимиты, 5xx).",
+      "fallbackModelItem": "Резерв {{index}}",
+      "addFallbackModel": "Добавить модель",
+      "searchModel": "Поиск модели...",
+      "loadingModels": "Загрузка моделей...",
+      "modelsError": "Ошибка загрузки моделей",
+      "noModels": "Нет доступных моделей",
+      "noModelsFound": "Модели не найдены",
+      "credential": "Ключ доступа",
+      "selectCredential": "Выберите ключ",
+      "selectCredentialFirst": "Сначала выберите ключ доступа",
+      "instructions": "Инструкции",
+      "role": "Роль",
+      "selectRole": "Выберите роль",
+      "roleUser": "Пользователь",
+      "roleAssistant": "Ассистент",
+      "contentPlaceholder": "Введите текст инструкции",
+      "expandInstruction": "Развернуть промпт",
+      "promptModalTitle": "Редактировать инструкцию",
+      "promptModalLabel": "Инструкция",
+      "additionalSettings": "Дополнительные настройки",
+      "tools": "Инструменты",
+      "allToolsAdded": "Все добавлены",
+      "addTool": "Добавить инструмент",
+      "responseFormat": "Формат ответа",
+      "selectFormat": "Выберите формат",
+      "formatText": "Текст",
+      "formatJSON": "JSON-объект",
+      "schemaBuilder": "Конструктор JSON-схемы",
+      "schemaDescription": "Создайте структуру JSON-ответа для LLM-модели",
+      "cancel": "Отмена",
+      "save": "Сохранить",
+      "includeChatHistory": "История чата",
+      "includeChatHistoryTooltip": "Если включено, в LLM будет отправлена полная история диалога сессии. Если выключено, будут отправлены только инструкции узла и текущее сообщение пользователя",
+      "saveToHistory": "Сохранять ответ в историю",
+      "saveToHistoryTooltip": "Если включено, ответ этого агента добавляется в общую историю диалога, которую видят следующие агенты. Отключите, чтобы сделать агента «тихим» — его ответ по-прежнему передается следующему узлу и в итоговый результат, но не попадает в общую историю.",
+      "historyField": "Поле для истории",
+      "historyFieldTooltip": "Если ответ в формате JSON, в общую историю сохраняется только это поле схемы, а не весь JSON. Полный ответ по-прежнему передается дальше и в итоговый результат.",
+      "historyFieldFull": "Весь ответ",
+      "knowledgeBases": "Базы знаний",
+      "selectKnowledgeBases": "Добавить базу знаний",
+      "noKnowledgeBases": "Нет баз знаний",
+      "noKnowledgeBasesFound": "Базы знаний не найдены",
+      "loadingKnowledgeBases": "Загрузка баз знаний...",
+      "searchKnowledgeBases": "Поиск базы знаний...",
+      "modelSettings": "Настройки модели",
+      "modelSettingsTooltip": "Расширенные параметры вызова LLM: температура, штрафы, формат ответа, рассуждения и другие опции, зависящие от модели",
+      "modelSettingsModalTitle": "Настройки модели",
+      "modelSettingsModalDescription": "Тонкая настройка параметров вызова LLM. Доступные поля зависят от выбранной модели.",
+      "close": "Закрыть"
+    },
+    "generic": {
+      "jsonPlaceholder": "{ \"key\": \"value\" }"
+    },
+    "httpRequest": {
+      "title": "HTTP-запрос",
+      "method": "Метод",
+      "selectMethod": "Выберите метод",
+      "url": "URL",
+      "urlPlaceholder": "https://api.example.com/endpoint",
+      "headers": "Заголовки",
+      "headerKey": "Ключ",
+      "headerValue": "Значение",
+      "queryParams": "Query-параметры",
+      "paramKey": "Ключ",
+      "paramValue": "Значение",
+      "body": "Тело запроса",
+      "bodyPlaceholder": "{\"key\": \"value\"}",
+      "timeout": "Таймаут (сек)"
+    }
+  },
+  "debug": {
+    "title": "Чат отладки",
+    "running": "Выполняется",
+    "clearHistory": "Очистить историю и начать новую сессию",
+    "noMessages": "Нет сообщений",
+    "noMessagesHelp": "Введите сообщение ниже и запустите воркфлоу",
+    "userMessage": "Вы:",
+    "error": "Ошибка:",
+    "inputPlaceholder": "Например: Привет! Как дела?",
+    "execute": "Выполнить",
+    "stop": "Остановить",
+    "executing": "Выполнение...",
+    "step": "Шаг {{number}}:",
+    "completed": "Завершено",
+    "failed": "Ошибка",
+    "input": "Вход",
+    "output": "Выход",
+    "duration": "{{ms}} мс",
+    "executionResult": "Результат выполнения",
+    "inputData": "Входные данные",
+    "outputData": "Выходные данные",
+    "llmRequest": "Запрос к LLM",
+    "stateBefore": "Состояние до",
+    "stateAfter": "Состояние после",
+    "projectStateAfter": "Состояние проекта после",
+    "noData": "Нет данных",
+    "creditsUsed": "Кредиты",
+    "ownKeyCost": "Свой ключ",
+    "totalCost": "Всего",
+    "executionError": "Выполнение завершилось с ошибкой",
+    "sessionClosed": "Сессия закрыта",
+    "sessionClosedDesc": "Агент закрыл сессию. Вы можете продолжить или начать новую сессию",
+    "continueSession": "Продолжить сессию",
+    "startNewSession": "Начать новую сессию",
+    "stateManagement": "Управление состоянием",
+    "agentState": "Состояние агента",
+    "projectState": "Состояние проекта",
+    "noStateVariables": "Нет переменных состояния",
+    "noProjectVariables": "Нет переменных проекта",
+    "invalidJson": "Некорректный формат JSON",
+    "resetToDefault": "Сбросить"
+  },
+  "nodes": {
+    "condition": {
+      "else": "Иначе"
+    },
+    "placeholder": {
+      "newElement": "Новый элемент",
+      "selectTypeInSidebar": "Выберите тип в боковой панели"
+    }
+  },
+  "stateVariables": {
+    "noVariablesText": "Нет переменных. Добавьте первую переменную.",
+    "selectTitle": "Переменные состояния",
+    "selectDescription": "Выберите переменную для обновления",
+    "selectPlaceholder": "Выберите переменную",
+    "noAvailableVariables": "Нет доступных переменных. Создайте первую переменную.",
+    "addVariable": "Добавить переменную",
+    "defaultValueLabel": "значение по умолчанию"
+  },
+  "availableVariables": {
+    "operators": {
+      "comparison": {
+        "equal": "Равно",
+        "notEqual": "Не равно",
+        "less": "Меньше",
+        "greater": "Больше",
+        "lessOrEqual": "Меньше или равно",
+        "greaterOrEqual": "Больше или равно"
+      },
+      "logical": {
+        "ternary": "Тернарный оператор",
+        "or": "Логическое ИЛИ",
+        "and": "Логическое И"
+      },
+      "comparisonTitle": "Сравнение",
+      "logicalTitle": "Логика",
+      "notFound": "Операторы не найдены",
+      "noAvailable": "Нет доступных операторов"
+    },
+    "variablesNotFound": "Переменные не найдены",
+    "noAvailableVariables": "Нет доступных переменных",
+    "groups": {
+      "input": "Входные данные",
+      "state": "Состояние",
+      "project": "Проект",
+      "workflow": "Агент",
+      "metadata": "Метаданные"
+    }
+  },
+  "workflowCard": {
+    "noDescription": "Без описания"
+  },
+  "versionsDropdown": {
+    "draft": "Черновик",
+    "error": "Ошибка",
+    "loadVersionError": "Не удалось загрузить версию"
+  },
+  "workflowActions": {
+    "additionalActions": "Дополнительные действия",
+    "rename": "Переименовать",
+    "renameAgent": "Переименовать агента",
+    "renameDescription": "Введите новое название агента",
+    "nameLabel": "Название",
+    "namePlaceholder": "Название агента",
+    "nameMinLength": "Название должно содержать не менее 3 символов",
+    "cancel": "Отмена",
+    "save": "Сохранить",
+    "renamed": "Воркфлоу переименован",
+    "renameError": "Не удалось переименовать агента",
+    "duplicate": "Дублировать",
+    "duplicateSuccess": "Агент успешно продублирован",
+    "duplicateError": "Не удалось продублировать агента",
+    "delete": "Удалить",
+    "deleteAgent": "Удалить агента",
+    "deleteDescription": "Вы уверены, что хотите удалить агента \"{{name}}\"?",
+    "deleteWarning": "Это действие нельзя отменить. Агент будет удален навсегда.",
+    "deleteConfirm": "Удалить",
+    "deleted": "Агент успешно удален",
+    "deleteError": "Не удалось удалить агента",
+    "move": "Переместить",
+    "moveAgent": "Переместить агента",
+    "moveDescription": "Выберите проект, в который переместить агента",
+    "moveProjectLabel": "Проект",
+    "moveProjectPlaceholder": "Выберите проект",
+    "moveSuccess": "Агент успешно перемещен",
+    "moveError": "Не удалось переместить агента",
+    "moveConfirm": "Переместить"
+  },
+  "publishSuccess": {
+    "title": "Агент опубликован",
+    "version": "Версия v{{version}}",
+    "workflowIdLabel": "Workflow ID",
+    "apiKeyLabel": "API-ключ",
+    "apiKeyAutoCreated": "Мы создали API-ключ для этой интеграции — сохраните его сейчас, он больше не будет показан.",
+    "apiKeyHint": "Мы не можем показать существующие ключи. Используйте имеющийся или создайте новый.",
+    "apiKeyCreate": "Создать ключ интеграции",
+    "apiKeyCreating": "Создание…",
+    "apiKeyCreateError": "Не удалось создать API-ключ",
+    "examplesLabel": "Примеры интеграции",
+    "supportPrompt": "Есть вопросы? Напишите нам:",
+    "copySuccess": "Скопировано",
+    "close": "Готово"
+  },
+  "clientSessions": {
+    "title": "Клиентские сессии",
+    "subtitle": "Управление данными клиентов и историей сессий",
+    "noSessions": "Клиентских сессий пока нет",
+    "clientId": "Client ID",
+    "lastActivity": "Последняя активность",
+    "executions": "Запуски",
+    "credits": "Кредиты",
+    "status": "Статус",
+    "active": "Активна",
+    "inactive": "Неактивна",
+    "never": "Никогда",
+    "onlyActive": "Только активные",
+    "showTestSessions": "Показывать тестовые сессии",
+    "searchPlaceholder": "Поиск по Client ID...",
+    "deactivate": "Деактивировать",
+    "deactivateConfirm": "Деактивировать клиентскую сессию?",
+    "deactivateWarning": "Клиентская сессия будет помечена как неактивная. Данные сессии сохранятся.",
+    "deactivateSuccess": "Клиентская сессия деактивирована",
+    "deactivateError": "Не удалось деактивировать клиентскую сессию",
+    "details": "Детали клиентской сессии",
+    "information": "Информация",
+    "createdAt": "Создана",
+    "updatedAt": "Обновлена",
+    "projectState": "Состояние проекта",
+    "metadata": "Метаданные",
+    "editMetadata": "Редактировать метаданные",
+    "editMetadataDescription": "Редактируйте метаданные в формате JSON",
+    "metadataUpdated": "Метаданные успешно обновлены",
+    "updateError": "Не удалось обновить метаданные",
+    "invalidJson": "Некорректный формат JSON",
+    "noExecutions": "Нет запусков для этого клиента",
+    "noChatSessions": "Нет чат-сессий для этого клиента",
+    "tabs": {
+      "overview": "Обзор",
+      "state": "Состояние",
+      "metadata": "Метаданные",
+      "executions": "Запуски",
+      "chatSessions": "Чат-сессии"
+    }
+  },
+  "projectSettings": {
+    "title": "Настройки проекта",
+    "subtitle": "Управление конфигурацией проекта и схемой состояния",
+    "projectInfo": "Информация о проекте",
+    "projectInfoDescription": "Основная информация о проекте",
+    "stateSchema": "Переменные проекта",
+    "stateSchemaDescription": "Безопасно храните API-ключи, секреты и состояние клиентов. Передавайте client_id, чтобы получить доступ к общим данным во всех агентах проекта.",
+    "addVariable": "Добавить переменную",
+    "variableName": "Название переменной",
+    "variableType": "Тип",
+    "defaultValue": "Значение по умолчанию",
+    "noVariables": "Переменные проекта не определены",
+    "noVariablesDescription": "Создавайте переменные для хранения API-ключей, секретов и состояния клиентов. Используйте client_id для обмена данными между агентами.",
+    "addVariableDescription": "Создать новую переменную проекта",
+    "nameRequired": "Название переменной обязательно",
+    "duplicateName": "Переменная с таким названием уже существует",
+    "variableAdded": "Переменная успешно добавлена",
+    "addError": "Не удалось добавить переменную",
+    "deleteVariable": "Удалить переменную?",
+    "deleteVariableWarning": "Вы уверены, что хотите удалить эту переменную? Это может повлиять на воркфлоу, которые ее используют.",
+    "variableDeleted": "Переменная успешно удалена",
+    "deleteError": "Не удалось удалить переменную"
+  },
+  "onboarding": {
+    "progress": "{{current}} из {{total}}",
+    "steps": {
+      "sidebar": {
+        "title": "Ваш конструктор",
+        "description": "Перетаскивайте блоки на холст, чтобы построить логику агента. Начните с узла агента — он отвечает за общение с LLM"
+      },
+      "agentNode": {
+        "title": "AI-агент — сердце вашего воркфлоу",
+        "description": "Перетащите этот блок на холст — он станет мозгом вашего агента. Использует LLM, чтобы понимать запросы и генерировать ответы. Работает из коробки с нашими системными ключами — просто начните тестировать!"
+      },
+      "debug": {
+        "title": "Тестируйте на лету",
+        "description": "Нажмите Play и протестируйте агента прямо сейчас. У вас уже есть стартовые кредиты — отправляйте сообщения и смотрите, как агент думает и отвечает на каждом шаге"
+      },
+      "credits": {
+        "title": "Кредиты и экономия",
+        "description": "Каждый запуск агента расходует кредиты с вашего баланса. Хотите тратить меньше? Подключите собственные API-ключи OpenAI, DeepSeek или других провайдеров — тогда всего 1 кредит за запрос вместо стоимости вызова LLM. Доступно на планах PRO и BUSINESS"
+      },
+      "publish": {
+        "title": "Готовы к продакшену?",
+        "description": "Когда агент готов — опубликуйте его. После этого его можно вызывать по API из любого приложения"
+      },
+      "final": {
+        "title": "Отлично! Давайте протестируем",
+        "description": "Чат отладки откроется автоматически. Отправьте сообщение и посмотрите на агента в действии. У вас уже есть стартовые кредиты!",
+        "telegramButton": "Присоединиться к Discord",
+        "startButton": "Начать создавать"
+      }
+    }
+  },
+  "billing": {
+    "unlimited": "Безлимитно",
+    "upgrade": "Улучшить",
+    "upgradePlan": "Улучшить план",
+    "upgradeToPlan": "Перейти на {{plan}}",
+    "availableInPlan": "Доступно в {{plan}}",
+    "viewPlans": "Посмотреть планы",
+    "highUsage": "У вас высокое потребление ресурсов",
+    "criticalUsage": "Вы достигли критического уровня потребления",
+    "nextReset": "Лимиты обновятся {{date}}",
+    "section": {
+      "title": "Оплата и использование",
+      "subtitle": "Управляйте тарифным планом и отслеживайте потребление ресурсов"
+    },
+    "usage": {
+      "agents": "Агенты",
+      "credits": "Кредиты"
+    },
+    "pricing": {
+      "title": "Выберите свой план",
+      "subtitle": "Выберите план, который подходит под задачи вашего проекта",
+      "popular": "Популярный",
+      "perMonth": "мес",
+      "currentPlan": "Текущий план",
+      "getStarted": "Начать бесплатно",
+      "contactSales": "Связаться с нами",
+      "subscribe": "Подписаться",
+      "business": {
+        "price": "По запросу",
+        "description": "Индивидуальные условия для крупных компаний",
+        "features": {
+          "consulting": "Экспертный консалтинг и аудит процессов",
+          "integration": "Интеграция под ключ и поддержка внедрения",
+          "sla": "Персональный SLA и выделенный менеджер",
+          "onpremise": "Возможность развертывания On-Premise"
+        }
+      },
+      "agents_one": "{{count}} агент",
+      "agents_few": "{{count}} агента",
+      "agents_many": "{{count}} агентов",
+      "agents_other": "{{count}} агента",
+      "unlimitedAgents": "Безлимитные агенты",
+      "agentsDesc": "Создавайте AI-агентов",
+      "creditsPerMonth": "кредитов/мес",
+      "creditsDesc": "Используйте для запуска агентов",
+      "rpmLimit_one": "{{count}} запрос/мин",
+      "rpmLimit_few": "{{count}} запроса/мин",
+      "rpmLimit_many": "{{count}} запросов/мин",
+      "rpmLimit_other": "{{count}} запроса/мин",
+      "rpmDesc": "Максимальная частота API-запросов",
+      "unlimitedRequests": "Безлимитные запросы со своими ключами",
+      "unlimitedRequestsDesc": "0 кредитов при использовании собственных API-ключей",
+      "ownApiKeys": "Собственные API-ключи",
+      "ownApiKeysDesc": "Используйте свои ключи LLM-провайдеров",
+      "projectVariables": "Переменные проекта",
+      "projectVariablesDesc": "Храните секреты и состояние клиентов с client_id",
+      "support": {
+        "community": "Поддержка сообщества",
+        "email_24h": "Поддержка по email (24 ч)",
+        "priority_4h_slack": "Приоритетная поддержка (4 ч) + Slack"
+      },
+      "supportDesc": {
+        "community": "Помощь через форум сообщества",
+        "email_24h": "Ответ в течение 24 часов",
+        "priority_4h_slack": "Быстрый ответ и прямой канал связи"
+      },
+      "allPlansInclude": "Все планы включают:",
+      "commonFeatures": {
+        "allProviders": "Все AI-провайдеры",
+        "visualBuilder": "Визуальный конструктор",
+        "apiAccess": "Доступ к API",
+        "sessionManagement": "Управление сессиями",
+        "logsMonitoring": "Логи и мониторинг"
+      },
+      "note": "Свяжитесь с нами, чтобы перейти на платный план или получить корпоративное решение"
+    },
+    "features": {
+      "projectVariables": {
+        "name": "Переменные проекта",
+        "description": "Храните API-ключи, секреты и состояние клиентов. Передайте client_id — и все агенты получат доступ к общим данным без потери контекста между диалогами."
+      }
+    },
+    "errors": {
+      "limitReached": "Достигнут лимит использования",
+      "agentsLimitReached": "Пора масштабироваться! 🚀",
+      "agentsLimitReachedHint": "Вы достигли лимита агентов на текущем плане. Перейдите на PRO или BUSINESS — получите больше агентов, безлимитные запросы и переменные проекта для сложных сценариев.",
+      "creditsLimitReached": "Кредиты закончились 💳",
+      "creditsInsufficient": "Недостаточно кредитов для запуска",
+      "creditsInsfficientHint": "Подключите собственные API-ключи (план PRO+) и платите всего 1 кредит за запрос. Или перейдите на план с большим количеством кредитов.",
+      "featureNotAvailable": "Эта функция недоступна на вашем текущем плане",
+      "rateLimitExceeded": "Превышен лимит запросов",
+      "rateLimitHint": "Вы превысили лимит {{rpm}} запросов в минуту. Замедлите запросы или улучшите план."
+    },
+    "limitWarning": {
+      "warning": {
+        "agents": {
+          "title": "Скоро вам понадобится больше агентов",
+          "description": "Использовано {{current}} из {{limit}} агентов ({{percentage}}%). Подумайте об улучшении плана, чтобы масштабировать проекты."
+        },
+        "credits": {
+          "title": "Кредиты заканчиваются",
+          "description": "Осталось {{current}} из {{limit}} кредитов ({{percentage}}%). Подключите собственные API-ключи или перейдите на план с большим количеством кредитов."
+        }
+      },
+      "critical": {
+        "agents": {
+          "title": "Пора улучшить план! 🚀",
+          "description": "Использовано {{current}} из {{limit}} агентов ({{percentage}}%). Перейдите на PRO или BUSINESS прямо сейчас, чтобы продолжить создавать."
+        },
+        "credits": {
+          "title": "Кредиты почти закончились! 💳",
+          "description": "Осталось {{current}} из {{limit}} кредитов ({{percentage}}%). Улучшите план или подключите API-ключи, чтобы сэкономить."
+        }
+      }
+    },
+    "credits": {
+      "balance": "Баланс кредитов",
+      "current": "Текущий баланс",
+      "used": "Использовано",
+      "remaining": "Осталось",
+      "nextRefill": "Следующее пополнение",
+      "refillIn": "Пополнение через",
+      "dateUnknown": "Дата неизвестна",
+      "transactions": "История транзакций",
+      "totalTransactions": "Всего транзакций",
+      "noTransactions": "Нет транзакций",
+      "viewAll": "Показать все",
+      "transactionTypes": {
+        "plan_grant": "Начисление по плану",
+        "llm_usage": "Использование LLM",
+        "request_fee": "Плата за запрос",
+        "manual_topup": "Ручное пополнение",
+        "refund": "Возврат"
+      },
+      "filters": {
+        "all": "Все типы",
+        "type": "Тип транзакции",
+        "period": "Период"
+      }
+    },
+    "systemKeys": {
+      "title": "Системные API-ключи",
+      "description": "Используются системные ключи LLM-провайдеров",
+      "upgradeMessage": "Собственные API-ключи доступны на планах STARTER, PRO и BUSINESS",
+      "benefit": "При использовании собственных ключей кредиты за запросы не списываются"
+    },
+    "payments": {
+      "confirmDialog": {
+        "title": "Подписка на план",
+        "subtitle": "Вы переходите на план {{plan}}",
+        "price": "Цена",
+        "autoRenewal": "Привязать карту для автопродления",
+        "autoRenewalHint": "Деньги будут списываться автоматически каждый месяц",
+        "cancel": "Отмена",
+        "submit": "Перейти к оплате",
+        "loading": "Создание платежа...",
+        "error": "Не удалось создать платеж. Попробуйте еще раз."
+      },
+      "successPage": {
+        "checking": "Проверяем статус платежа...",
+        "checkingHint": "Это займет несколько секунд",
+        "success": "Подписка активирована!",
+        "successHint": "Теперь вам доступны все возможности плана {{plan}}",
+        "goToAgents": "Перейти к агентам",
+        "error": "Платеж не прошел",
+        "errorHint": "Попробуйте еще раз или обратитесь в поддержку",
+        "retry": "Попробовать снова",
+        "timeout": "Не удалось проверить статус",
+        "timeoutHint": "Если деньги были списаны, план активируется автоматически"
+      }
+    }
+  },
+  "variableForm": {
+    "name": "Название",
+    "namePlaceholder": "Введите название переменной",
+    "nameRequired": "Название переменной не может быть пустым",
+    "duplicateName": "Переменная с таким названием уже существует",
+    "defaultValue": "Значение по умолчанию",
+    "optional": "(необязательно)",
+    "stringPlaceholder": "Введите значение",
+    "numberPlaceholder": "Введите число",
+    "booleanPlaceholder": "Выберите значение",
+    "projectVariable": "Переменная проекта",
+    "projectVariableDescription": "Доступна во всех воркфлоу проекта",
+    "projectVariableUpgradeRequired": "Перейдите на план Pro, чтобы использовать переменные проекта",
+    "objectPlaceholder": "Введите JSON-объект, например {\"key\": \"value\"}",
+    "invalidJson": "Некорректный формат JSON",
+    "objectMustBeObject": "Значение должно быть JSON-объектом",
+    "editObjectValue": "Редактировать",
+    "objectEmpty": "Пустой объект",
+    "objectSummary": "Ключей: {{count}}"
+  },
+  "objectValueEditor": {
+    "title": "Значение по умолчанию",
+    "description": "Задайте значение объекта — через конструктор или JSON.",
+    "tabConstructor": "Конструктор",
+    "tabJson": "JSON",
+    "addKey": "Добавить ключ",
+    "keyPlaceholder": "ключ",
+    "valuePlaceholder": "значение",
+    "emptyObject": "Пусто. Добавьте первый ключ.",
+    "invalidJson": "Некорректный JSON",
+    "mustBeObject": "Значение должно быть объектом"
+  },
+  "nodeTemplates": {
+    "templates": "Шаблоны",
+    "saveAsTemplate": "Сохранить как шаблон",
+    "edit": "Редактировать",
+    "duplicate": "Дублировать",
+    "modal": {
+      "title": "Сохранить как шаблон",
+      "description": "Создайте переиспользуемый шаблон из этого узла",
+      "name": "Название",
+      "namePlaceholder": "Мой шаблон",
+      "nameRequired": "Название обязательно",
+      "nameMaxLength": "Название не должно превышать 255 символов",
+      "templateDescription": "Описание",
+      "descriptionPlaceholder": "Описание шаблона (необязательно)",
+      "descriptionMaxLength": "Описание не должно превышать 1000 символов"
+    },
+    "editModal": {
+      "title": "Редактировать шаблон",
+      "description": "Измените название и описание шаблона"
+    },
+    "duplicateModal": {
+      "title": "Дублировать шаблон",
+      "description": "Выберите проект, в который скопировать шаблон",
+      "selectProject": "Выберите проект",
+      "noOtherProjects": "Нет других проектов для копирования"
+    },
+    "createSuccess": "Шаблон успешно создан",
+    "createError": "Не удалось создать шаблон",
+    "updateSuccess": "Шаблон обновлен",
+    "updateError": "Не удалось обновить шаблон",
+    "duplicateSuccess": "Шаблон продублирован",
+    "duplicateError": "Не удалось продублировать шаблон",
+    "deleteSuccess": "Шаблон удален",
+    "deleteError": "Не удалось удалить шаблон",
+    "deleteConfirm": "Удалить шаблон?",
+    "deleteWarning": "Вы уверены, что хотите удалить \"{{name}}\"?",
+    "noTemplates": "Нет сохраненных шаблонов",
+    "noTemplatesDescription": "Сохраните узел как шаблон для быстрого переиспользования"
+  },
+  "knowledgeBases": {
+    "title": "Базы знаний",
+    "subtitle": "Управляйте базами знаний для ваших агентов",
+    "create": "Создать базу знаний",
+    "empty": "Нет баз знаний",
+    "emptyDescription": "Создайте базу знаний, чтобы агенты могли использовать ваши документы",
+    "columns": {
+      "name": "Название",
+      "description": "Описание",
+      "documents": "Документы",
+      "characters": "Символы",
+      "createdAt": "Создана",
+      "actions": "Действия"
+    },
+    "createModal": {
+      "title": "Создать базу знаний",
+      "editTitle": "Редактировать базу знаний",
+      "nameLabel": "Название",
+      "namePlaceholder": "Введите название базы знаний",
+      "descriptionLabel": "Описание",
+      "descriptionPlaceholder": "Необязательное описание",
+      "nameRequired": "Название обязательно"
+    },
+    "deleteDialog": {
+      "title": "Удалить базу знаний",
+      "description": "Вы уверены, что хотите удалить базу знаний \"{{name}}\"? Все документы будут удалены навсегда."
+    },
+    "createSuccess": "База знаний создана",
+    "createError": "Не удалось создать базу знаний",
+    "updateSuccess": "База знаний обновлена",
+    "updateError": "Не удалось обновить базу знаний",
+    "deleteSuccess": "База знаний удалена",
+    "deleteError": "Не удалось удалить базу знаний"
+  },
+  "knowledgeBaseDetails": {
+    "backToList": "Базы знаний",
+    "usage": "Использовано {{used}} / {{max}} символов",
+    "addText": "Добавить текст",
+    "uploadPDF": "Загрузить PDF",
+    "documentsTitle": "Документы",
+    "empty": "Нет документов",
+    "emptyDescription": "Добавьте текст или загрузите PDF, чтобы наполнить базу знаний",
+    "columns": {
+      "name": "Название",
+      "type": "Тип",
+      "characters": "Символы",
+      "createdAt": "Добавлен",
+      "actions": "Действия"
+    },
+    "docType": {
+      "text": "Текст",
+      "pdf": "PDF"
+    },
+    "addTextModal": {
+      "title": "Добавить текст",
+      "nameLabel": "Название документа",
+      "namePlaceholder": "Введите название документа",
+      "contentLabel": "Содержимое",
+      "contentPlaceholder": "Вставьте ваш текст сюда...",
+      "nameRequired": "Название обязательно",
+      "contentRequired": "Содержимое обязательно"
+    },
+    "uploadPDFModal": {
+      "title": "Загрузить PDF",
+      "nameLabel": "Название документа",
+      "namePlaceholder": "Введите название документа",
+      "fileLabel": "PDF-файл",
+      "filePlaceholder": "Выберите PDF-файл",
+      "uploading": "Загрузка...",
+      "nameRequired": "Название обязательно",
+      "fileRequired": "Пожалуйста, выберите PDF-файл"
+    },
+    "viewDocumentModal": {
+      "title": "Содержимое документа"
+    },
+    "deleteDialog": {
+      "title": "Удалить документ",
+      "description": "Вы уверены, что хотите удалить документ \"{{name}}\"?"
+    },
+    "addSuccess": "Документ добавлен",
+    "addError": "Не удалось добавить документ",
+    "uploadSuccess": "PDF загружен",
+    "uploadError": "Не удалось загрузить PDF",
+    "deleteSuccess": "Документ удален",
+    "deleteError": "Не удалось удалить документ",
+    "errorDuplicate": "Документ с таким содержимым уже существует",
+    "errorNoText": "PDF не содержит текста (отсканированный документ без OCR)"
+  },
+  "schemaBuilder": {
+    "title": "Структурированный вывод (JSON)",
+    "description": "Модель сгенерирует JSON-объект, соответствующий этой схеме",
+    "simpleMode": "Визуальный",
+    "advancedMode": "JSON",
+    "schemaName": "Название",
+    "properties": "Свойства",
+    "noProperties": "Нет свойств. Добавьте первое свойство.",
+    "addProperty": "Добавить свойство",
+    "jsonSyntaxError": "Некорректный синтаксис JSON",
+    "jsonMustBeObject": "Схема должна быть JSON-объектом"
+  },
+  "meta": {
+    "title": "Assemblix - Визуальный конструктор AI-агентов",
+    "description": "Создавайте умных AI-агентов без кода в визуальном конструкторе Assemblix. Автоматизируйте бизнес-процессы, создавайте чат-ботов и воркфлоу.",
+    "keywords": "AI-агенты, конструктор агентов, визуальный редактор, конструктор воркфлоу, автоматизация, чат-боты, искусственный интеллект, no-code, low-code, Assemblix"
+  }
+}

--- a/assemblix-app-web/src/shared/lib/format-date.ts
+++ b/assemblix-app-web/src/shared/lib/format-date.ts
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 const LOCALE_MAP: Record<string, string> = {
   ru: "ru-RU",
   en: "en-US",
+  es: "es-ES",
 };
 
 function toLocale(lang: string): string {

--- a/assemblix-app-web/src/shared/ui/header.tsx
+++ b/assemblix-app-web/src/shared/ui/header.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 import { Button } from "./button";
 import { Divider } from "./divider";
+import { LanguageSwitcher } from "./language-switcher";
 import {
   Tooltip,
   TooltipContent,
@@ -244,6 +245,13 @@ export const Header = () => {
                       </>
                     )}
                   </Button>
+
+                  <Divider />
+
+                  {/* Language */}
+                  <div className="px-3 py-1.5">
+                    <LanguageSwitcher className="w-full" />
+                  </div>
 
                   <Divider />
 

--- a/assemblix-app-web/src/shared/ui/index.ts
+++ b/assemblix-app-web/src/shared/ui/index.ts
@@ -10,6 +10,7 @@ export * from "./add-variable-popover";
 export * from "./popover";
 export * from "./dialog";
 export * from "./select";
+export * from "./language-switcher";
 export * from "./cel-helper";
 export * from "./json-schema-builder";
 export * from "./pagination";

--- a/assemblix-app-web/src/shared/ui/language-switcher.tsx
+++ b/assemblix-app-web/src/shared/ui/language-switcher.tsx
@@ -1,0 +1,48 @@
+import { Languages } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { BUNDLED_LANGS } from "@/shared/i18n";
+import { LANGUAGE_LABELS } from "@/shared/i18n/languages";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./select";
+
+type LanguageSwitcherProps = {
+  className?: string;
+};
+
+export const LanguageSwitcher = ({ className }: LanguageSwitcherProps) => {
+  const { i18n } = useTranslation();
+
+  // Nothing to switch between when a single locale is bundled.
+  if (BUNDLED_LANGS.length <= 1) return null;
+
+  const current = BUNDLED_LANGS.includes(i18n.language)
+    ? i18n.language
+    : BUNDLED_LANGS[0];
+
+  const handleChange = (lang: string) => {
+    i18n.changeLanguage(lang);
+  };
+
+  return (
+    <Select value={current} onValueChange={handleChange}>
+      <SelectTrigger className={className}>
+        <div className="flex items-center gap-2">
+          <Languages className="h-4 w-4" />
+          <SelectValue />
+        </div>
+      </SelectTrigger>
+      <SelectContent>
+        {BUNDLED_LANGS.map((lang) => (
+          <SelectItem key={lang} value={lang}>
+            {LANGUAGE_LABELS[lang] ?? lang}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};


### PR DESCRIPTION
## What & why

`es.json` and `ru.json` were already fully translated (all 1074 EN keys; `ru` adds correct plural forms) but **unreachable**: the i18n layer only ever registered English, `VITE_LANGS=en`, and there was no language-switcher UI anywhere. This wires the locales in and lets users pick their language.

## Changes

- **Data-driven locale registration** — `shared/i18n/index.ts` now builds `resources` from an `ALL_TRANSLATIONS` map over `AVAILABLE_LANGS` instead of hardcoding `en`; exports `BUNDLED_LANGS`. Adding a future language is a one-line change. The existing `supportedLngs` / stale-cache self-healing logic is preserved and now correctly keeps `es`/`ru`.
- **Reusable `LanguageSwitcher`** (`shared/ui/language-switcher.tsx`, shadcn `Select`) → calls `i18n.changeLanguage()` (auto-persists to `localStorage` + updates the `Accept-Language` header). Placed in the **header user menu** and the **Settings page**, mirroring the existing theme control.
- **Native labels** (`shared/i18n/languages.ts`: English / Español / Русский) + `settings.language` key in en/es/ru.
- **`es-ES`** added to the date/number `LOCALE_MAP` (`shared/lib/format-date.ts`).
- **`.env.example`** default bumped to `VITE_LANGS=en,es,ru`.

> Note: the real root `.env` is gitignored (secrets), so self-hosters pick up es/ru via the updated `.env.example`. `VITE_LANGS` is read at build/dev-server start — restart the web server to bundle the new locales.

## Verification

- `npm run build` (`tsc -b` + vite) passes — es/ru JSON are structurally compatible with `typeof en`.
- Drove a fresh dev server with Playwright: the login page switches **EN → ES → RU**, the selection persists across reload, and the console is clean (no errors / missing keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)