### PR TITLE
fix(execution): stop node self-loop from spinning to the cycle cap

### DIFF
--- a/assemblix-app-api/assemblix_api/execution/graph_navigator.py
+++ b/assemblix-app-api/assemblix_api/execution/graph_navigator.py
@@ -55,6 +55,11 @@ class GraphNavigator:
         Edges pointing to non-existent nodes are silently skipped so that
         stale references left in a saved workflow JSON do not crash execution.
 
+        Self-loop edges (target == current_node_id) are also skipped: a node must
+        never route back to itself, otherwise the executor would re-run it until the
+        per-node cycle cap trips. If the only outgoing edge is a self-loop, None is
+        returned and the executor fails fast with NoNextNodeError.
+
         Args:
             edges: List of edges from workflow
             nodes: List of node configs from workflow (used to validate targets)
@@ -85,14 +90,22 @@ class GraphNavigator:
                     if e.source == current_node_id
                     and e.source_handle == source_handle
                     and e.target in valid_node_ids
+                    and e.target != current_node_id
                 ),
                 None,
             )
             return edge.target if edge else None
 
-        # For regular nodes: find first edge whose target actually exists
+        # For regular nodes: find first edge whose target actually exists and is
+        # not the node itself (self-loops are never followed).
         edge = next(
-            (e for e in edges if e.source == current_node_id and e.target in valid_node_ids),
+            (
+                e
+                for e in edges
+                if e.source == current_node_id
+                and e.target in valid_node_ids
+                and e.target != current_node_id
+            ),
             None,
         )
         return edge.target if edge else None

--- a/assemblix-app-api/tests/unit/test_graph_navigator.py
+++ b/assemblix-app-api/tests/unit/test_graph_navigator.py
@@ -1,0 +1,87 @@
+"""Unit tests for GraphNavigator.find_next_node (assemblix_api/execution/graph_navigator.py).
+
+Focus on the self-loop guard: a node must never be routed back to itself. An edge
+whose target is the current node is skipped; the first real (non-self) edge is taken
+instead, and when no such edge exists find_next_node returns None so the executor
+fails fast with NoNextNodeError rather than spinning until the cycle cap trips.
+"""
+
+from __future__ import annotations
+
+from assemblix_api.execution.graph_navigator import GraphNavigator
+from assemblix_api.schemas.workflow import Edge
+
+
+def _edge(source: str, target: str, handle: str | None = None) -> Edge:
+    return Edge(
+        id=f"{source}->{target}",
+        source=source,
+        target=target,
+        source_handle=handle,
+    )
+
+
+def test_find_next_node_returns_normal_target() -> None:
+    # Arrange
+    nodes = [{"id": "A", "type": "agent"}, {"id": "B", "type": "end"}]
+    edges = [_edge("A", "B")]
+
+    # Act
+    result = GraphNavigator.find_next_node(edges, nodes, "A")
+
+    # Assert
+    assert result == "B"
+
+
+def test_find_next_node_skips_self_loop_and_takes_real_edge() -> None:
+    # Arrange — the self-loop is listed FIRST, exactly like the prod bug.
+    nodes = [{"id": "A", "type": "agent"}, {"id": "B", "type": "end"}]
+    edges = [_edge("A", "A"), _edge("A", "B")]
+
+    # Act
+    result = GraphNavigator.find_next_node(edges, nodes, "A")
+
+    # Assert — the self edge is ignored, execution moves forward to B.
+    assert result == "B"
+
+
+def test_find_next_node_returns_none_when_only_self_loop() -> None:
+    # Arrange — the single outgoing edge points back at the node itself.
+    nodes = [{"id": "A", "type": "agent"}]
+    edges = [_edge("A", "A")]
+
+    # Act
+    result = GraphNavigator.find_next_node(edges, nodes, "A")
+
+    # Assert — no valid successor → None (executor raises NoNextNodeError).
+    assert result is None
+
+
+def test_find_next_node_prod_repro_dead_edge_then_self_then_real() -> None:
+    # Arrange — reproduces the prod graph exactly: the agent's outgoing edges were
+    # ordered [-> deleted node, -> itself, -> real next]. Before the guard the self
+    # edge won and the node ran until the cycle cap tripped.
+    nodes = [{"id": "agent", "type": "agent"}, {"id": "cond", "type": "condition"}]
+    edges = [
+        _edge("agent", "deleted-node"),  # target missing → skipped (pre-existing)
+        _edge("agent", "agent"),  # self-loop → skipped (new guard)
+        _edge("agent", "cond"),  # first real successor
+    ]
+
+    # Act
+    result = GraphNavigator.find_next_node(edges, nodes, "agent")
+
+    # Assert
+    assert result == "cond"
+
+
+def test_find_next_node_excludes_self_loop_on_condition_branch() -> None:
+    # Arrange — a branch edge that loops back to the condition node itself.
+    nodes = [{"id": "C", "type": "condition"}]
+    edges = [_edge("C", "C", handle="source_C_0")]
+
+    # Act
+    result = GraphNavigator.find_next_node(edges, nodes, "C", source_handle_index=0)
+
+    # Assert
+    assert result is None

--- a/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/canvas.tsx
+++ b/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/canvas.tsx
@@ -575,8 +575,19 @@ const FlowCanvas = ({
     ],
   );
 
+  // Запрет соединения ноды с самой собой: узел не может быть собственной
+  // следующей нодой (иначе исполнитель зациклится на нём до кап-лимита).
+  const isValidConnection = useCallback(
+    (connection: Connection | Edge) => connection.source !== connection.target,
+    [],
+  );
+
   const onConnect = useCallback(
     (params: Connection) => {
+      // Страховка на случай программного добавления ребра в обход isValidConnection.
+      if (params.source === params.target) {
+        return;
+      }
       if (!isDebugMode && !isViewMode) {
         // Используем nodes/edges из замыкания - состояние ДО подключения!
         takeSnapshot(nodes, edges);
@@ -899,6 +910,7 @@ const FlowCanvas = ({
         }
         onConnect={isDebugMode || isViewMode ? undefined : onConnect}
         onConnectEnd={isDebugMode || isViewMode ? undefined : onConnectEnd}
+        isValidConnection={isValidConnection}
         onDrop={isDebugMode || isViewMode ? undefined : onDrop}
         onDragOver={isDebugMode || isViewMode ? undefined : onDragOver}
         onPaneClick={handlePaneClick}


### PR DESCRIPTION
## Проблема

Агентская нода с ребром «сама на себя» (`source == target`) заставляла граф-навигатор возвращать управление на ту же ноду. Она перезапускалась, пока не срабатывал per-node кап (`max_node_executions = 10`) → падение с `cycle_detection`.

Симптомы были непрозрачными:
- каждый прогон ноды логировался как **COMPLETED** (нода зелёная, ответ LLM адекватный);
- ошибка не привязывалась к ноде — `failedNodeId = null` (cycle-ошибка бросается до выполнения ноды и не оборачивается в `NodeExecutionError`);
- в сводке прогона `stepsCount: 0` / `totalCredits: 0` (контекст откатывается на pre-loop при исключении в `_execution_loop`).

Навигатор для не-branching ноды берёт **первое** ребро с существующим target'ом, поэтому self-ребро выигрывало у настоящего следующего ребра, а мёртвое ребро на удалённую ноду просто пропускалось.

## Правки

**Бэкенд** — `GraphNavigator.find_next_node` ([graph_navigator.py](../blob/fix/workflow-node-self-loop/assemblix-app-api/assemblix_api/execution/graph_navigator.py)):
- в обеих ветках (обычная нода и ветка `condition`) исключается `e.target == current_node_id`;
- если не-self реальное ребро есть → идём в него (это чинит и уже сохранённые сломанные воркфлоу);
- если валидных не-self рёбер не осталось → `None` → исполнитель падает сразу с `NoNextNodeError`, а не крутит ноду до кап-лимита.

**Фронт** — canvas ([canvas.tsx](../blob/fix/workflow-node-self-loop/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/canvas.tsx)):
- `isValidConnection` блокирует соединение `source == target` прямо при перетаскивании;
- плюс защитный early-return в `onConnect`.

## Тесты / проверки

- Новый `tests/unit/test_graph_navigator.py` (TDD: сначала RED, потом GREEN), включая тест-репро точного прод-кейса `[→удалённая, →self, →condition] ⇒ condition`.
- Полный backend unit-сьют: **71 passed**, регрессий нет.
- ruff + mypy (изменённые файлы) — clean.
- Фронт `tsc -b` + eslint (`canvas.tsx`) — clean. Юнит-тестов на фронте нет (нет тест-раннера).

## Осознанно вне скоупа (обсуждаемо отдельно)

- Валидация графа на сохранении (запрет self-loop / >1 исходящего ребра у не-branching ноды).
- Потеря учёта шагов/стоимости при cycle-ошибке (`stepsCount:0`, `totalCredits:0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)