### PR TITLE
feat: api-keys whoami returns the key's project

### DIFF
--- a/assemblix-app-api/assemblix_api/api/rest/api_keys.py
+++ b/assemblix-app-api/assemblix_api/api/rest/api_keys.py
@@ -13,6 +13,7 @@ from assemblix_api.core.auth_context import AuthContext
 from assemblix_api.dependencies import (
     get_api_key_service,
     get_auth_context,
+    get_project_id_from_token,
     get_project_service,
 )
 from assemblix_api.dto.requests.api_key import CreateAPIKeyRequest
@@ -25,6 +26,14 @@ from assemblix_api.services.api_key_service import APIKeyService
 from assemblix_api.services.project_service import ProjectService
 
 router = APIRouter(prefix="/api-keys", tags=["API Keys"])
+
+
+@router.get("/whoami")
+async def whoami(
+    project_id: UUID = Depends(get_project_id_from_token),
+) -> dict[str, str]:
+    """Return the project the calling API key is scoped to."""
+    return {"projectId": str(project_id)}
 
 
 @router.get("/", response_model=APIKeyListResponse)

--- a/assemblix-app-api/tests/integration/test_api_keys_whoami.py
+++ b/assemblix-app-api/tests/integration/test_api_keys_whoami.py
@@ -1,0 +1,16 @@
+"""GET /api/api-keys/whoami — resolves the calling sk_ key's project."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+async def test_whoami_returns_key_project(client: Any, api_key: Any, auth_user: Any) -> None:
+    # Arrange: api_key is an sk_ key scoped to auth_user's default project.
+
+    # Act
+    resp = await client.get("/api/api-keys/whoami", headers=api_key.headers)
+
+    # Assert
+    assert resp.status_code == 200
+    assert resp.json() == {"projectId": str(auth_user.project_id)}


### PR DESCRIPTION
## What

Adds `GET /api/api-keys/whoami`, returning `{"projectId": "<uuid>"}` for the calling API key.

## Why

Prerequisite for the standalone Assemblix MCP server (`assemblix-mcp`, developed in the separate `assemblix-aitools` repo). The MCP client authenticates with a single project-scoped `sk_` key and calls `whoami` to learn which project the key is scoped to — so `projectId` is never accepted from the caller and cross-project access stays structurally impossible.

## Details

- Route declared **before** `GET /{key_id}` so `/whoami` isn't captured as `key_id="whoami"`.
- Reuses the existing `get_project_id_from_token` dependency (resolves `sk_` → `project_id`); no new auth logic.
- Endpoint is intentionally unscoped — it only echoes the calling key's own project.

## Test

Integration test asserts a project-scoped `sk_` key gets its own `projectId` back (reuses existing key-minting fixtures). `test_api_key_scoping.py` + new test: 22 passed; ruff/mypy clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)