### PR TITLE
feat: default project_id from the API key (drop explicit param requirement)

### DIFF
--- a/assemblix-app-api/assemblix_api/api/rest/_scope.py
+++ b/assemblix-app-api/assemblix_api/api/rest/_scope.py
@@ -1,0 +1,29 @@
+"""Shared helper for resolving the effective project of a request.
+
+Endpoints that historically required an explicit ``project_id`` (built for the
+JWT frontend, where one user spans many projects) can accept it optionally: when
+omitted, a project-scoped API key supplies its own project. JWT callers, which
+carry no scoped project, must still pass one.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import HTTPException, status
+
+from assemblix_api.core.auth_context import AuthContext
+
+
+def resolve_project_id(explicit: UUID | None, auth: AuthContext) -> UUID:
+    """Return the explicit project_id, else the API key's scoped project.
+
+    Raises 400 when neither is available (e.g. a JWT caller that omitted it).
+    """
+    effective = explicit or auth.scoped_project_id
+    if effective is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="project_id is required unless using a project-scoped API key",
+        )
+    return effective

--- a/assemblix-app-api/assemblix_api/api/rest/executions.py
+++ b/assemblix-app-api/assemblix_api/api/rest/executions.py
@@ -25,6 +25,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from assemblix_api.api.rest._scope import resolve_project_id
 from assemblix_api.billing.service import BillingService
 from assemblix_api.core.auth_context import AuthContext
 from assemblix_api.core.settings import get_settings
@@ -748,7 +749,11 @@ async def in_flight_executions(
 
 @execution_detail_router.get("/", response_model=PaginatedResponse[ExecutionInfoResponse])
 async def list_executions(
-    project_id: UUID = Query(..., description="Project ID"),
+    project_id: UUID | None = Query(
+        default=None,
+        description="Project ID. Optional when authenticated with a project-scoped "
+        "API key — defaults to the key's project.",
+    ),
     page: int = Query(default=1, ge=1, description="Page number"),
     limit: int = Query(default=50, ge=1, le=100, description="Page size"),
     workflow_id: UUID | None = Query(default=None, description="Filter by workflow ID"),
@@ -777,6 +782,7 @@ async def list_executions(
     - date_from/date_to: range of execution start dates
     - include_debug: whether to show debug executions
     """
+    project_id = resolve_project_id(project_id, auth)
     await project_service.authorize_project_access(auth, project_id)
 
     offset = (page - 1) * limit

--- a/assemblix-app-api/assemblix_api/api/rest/workflows.py
+++ b/assemblix-app-api/assemblix_api/api/rest/workflows.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, status
 
+from assemblix_api.api.rest._scope import resolve_project_id
 from assemblix_api.core.auth_context import AuthContext
 from assemblix_api.dependencies import (
     get_auth_context,
@@ -28,7 +29,11 @@ router = APIRouter(prefix="/workflows", tags=["Workflows"])
 
 @router.get("/", response_model=list[WorkflowBaseResponse])
 async def list_workflows(
-    project_id: UUID = Query(..., description="Project ID"),
+    project_id: UUID | None = Query(
+        default=None,
+        description="Project ID. Optional when authenticated with a project-scoped "
+        "API key — defaults to the key's project.",
+    ),
     skip: int = Query(default=0, ge=0, description="Number of records to skip"),
     limit: int = Query(default=100, ge=1, le=1000, description="Maximum number of records"),
     is_active: bool | None = Query(default=None, description="Filter by active status"),
@@ -39,10 +44,11 @@ async def list_workflows(
     project_service: ProjectService = Depends(get_project_service),
 ):
     """List project workflows with optional status filtering."""
-    await project_service.authorize_project_access(auth, project_id)
+    effective_project_id = resolve_project_id(project_id, auth)
+    await project_service.authorize_project_access(auth, effective_project_id)
 
     workflows = await service.get_project_workflows(
-        project_id,
+        effective_project_id,
         skip=skip,
         limit=limit,
         is_active=is_active,
@@ -84,6 +90,7 @@ async def create_workflow(
     """Create a new workflow."""
     language = "en"
 
+    data.project_id = resolve_project_id(data.project_id, auth)
     project = await project_service.authorize_project_access(auth, data.project_id)
 
     # Create the workflow, enforcing billing limits.

--- a/assemblix-app-api/assemblix_api/dto/requests/workflow.py
+++ b/assemblix-app-api/assemblix_api/dto/requests/workflow.py
@@ -9,7 +9,11 @@ from assemblix_api.schemas import Edge, Node, StateVariable
 
 
 class WorkflowCreateRequest(DTOModel):
-    project_id: UUID = Field(..., description="ID of the project this workflow belongs to")
+    project_id: UUID | None = Field(
+        default=None,
+        description="ID of the project this workflow belongs to. Optional when "
+        "authenticated with a project-scoped API key — defaults to the key's project.",
+    )
     name: str | None = Field(
         default=None,
         max_length=255,

--- a/assemblix-app-api/tests/integration/test_api_key_implicit_project.py
+++ b/assemblix-app-api/tests/integration/test_api_key_implicit_project.py
@@ -1,0 +1,73 @@
+"""project_id is implicit for API keys: the three endpoints that used to require it
+(workflows list/create, executions list) now default to the key's scoped project."""
+
+from __future__ import annotations
+
+
+async def test_list_workflows_defaults_to_key_project(client, api_key) -> None:
+    # Arrange: api_key is scoped to its own project; send NO project_id.
+    # Act
+    resp = await client.get("/api/workflows/", headers=api_key.headers)
+    # Assert
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+async def test_create_workflow_defaults_to_key_project(client, api_key) -> None:
+    # Arrange: body carries no projectId.
+    # Act
+    resp = await client.post("/api/workflows/", json={"name": "WF"}, headers=api_key.headers)
+    # Assert: created (defaulting worked) and readable back under the key's scope,
+    # which proves it landed in the key's project (a foreign one would 403 by id).
+    assert resp.status_code == 201
+    workflow_id = resp.json()["id"]
+    readback = await client.get(f"/api/workflows/{workflow_id}", headers=api_key.headers)
+    assert readback.status_code == 200
+
+
+async def test_list_executions_defaults_to_key_project(client, api_key) -> None:
+    # Act
+    resp = await client.get("/api/executions/", headers=api_key.headers)
+    # Assert
+    assert resp.status_code == 200
+    assert "data" in resp.json()
+
+
+async def test_create_workflow_rejects_explicit_foreign_project(
+    client, api_key, auth_headers
+) -> None:
+    # Arrange: a second project in the same org that the key is NOT scoped to.
+    proj = await client.post(
+        "/api/projects/", json={"name": "Other"}, headers=auth_headers
+    )
+    other_project_id = proj.json()["id"]
+    # Act: the key tries to create in the foreign project by passing it explicitly.
+    resp = await client.post(
+        "/api/workflows/",
+        json={"name": "WF", "projectId": other_project_id},
+        headers=api_key.headers,
+    )
+    # Assert: explicit foreign project is still rejected (not laundered via the key).
+    assert resp.status_code == 403
+
+
+async def test_list_workflows_jwt_without_project_id_returns_400(client, auth_headers) -> None:
+    # Arrange: JWT caller carries no scoped project, so project_id is still required.
+    # Act
+    resp = await client.get("/api/workflows/", headers=auth_headers)
+    # Assert
+    assert resp.status_code == 400
+
+
+async def test_list_executions_jwt_without_project_id_returns_400(client, auth_headers) -> None:
+    # Act
+    resp = await client.get("/api/executions/", headers=auth_headers)
+    # Assert
+    assert resp.status_code == 400
+
+
+async def test_create_workflow_jwt_without_project_id_returns_400(client, auth_headers) -> None:
+    # Act
+    resp = await client.post("/api/workflows/", json={"name": "WF"}, headers=auth_headers)
+    # Assert
+    assert resp.status_code == 400


### PR DESCRIPTION
## What

Makes `project_id` **optional** on the three endpoints that still required it explicitly:
- `GET /api/workflows/`
- `POST /api/workflows/`
- `GET /api/executions/`

When omitted, it defaults to the API key's scoped project via a shared `resolve_project_id(explicit, auth)` helper.

## Why

These endpoints were built for the JWT frontend, where one user spans many projects and must say which. For a **project-scoped API key** the project is already pinned by the key, so requiring the caller to also send `project_id` is pure redundancy — the standalone MCP server had to do a `whoami` round-trip on every call just to echo it back. This removes that entirely.

## Behavior

- **sk_ key, no `project_id`** → uses the key's project. ✅
- **sk_ key, explicit foreign `project_id`** → still **403** (scoping unchanged; the resolved id is authorized, so a foreign explicit id is never laundered through the key). ✅
- **JWT caller (no scoped project), no `project_id`** → **400** (still required). JWT with `project_id` unchanged. ✅
- `create_workflow` persists to the resolved project (handler sets `data.project_id` before the service call).

## Tests

New `tests/integration/test_api_key_implicit_project.py` (7 tests): defaulting for all three endpoints, explicit-foreign-still-403 on create, JWT-without-project-id → 400 on workflows list, create, and executions list. Existing scoping + workflow-create suites pass unchanged.

## Follow-ups

- Supersedes PR #33 (`whoami`) — that endpoint is no longer needed and its PR should be closed.
- Unblocks `assemblix-mcp` 0.2.0 (drops `project_id`/`whoami`); publish only **after this is deployed**, else the param-less requests 422 against the old backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)