### PR TITLE
fix: make voice debug audio work with gpt-4o-transcribe

### DIFF
--- a/assemblix-app-api/assemblix_api/external/voice/transcription.py
+++ b/assemblix-app-api/assemblix_api/external/voice/transcription.py
@@ -29,6 +29,18 @@ class Transcript(BaseModel):
     duration: float | None = None
 
 
+def _supports_verbose_json(model: str) -> bool:
+    """Whether the model accepts ``response_format="verbose_json"`` (language/duration).
+
+    Only whisper-family models do; gpt-4o-transcribe* reject it and support json/text
+    only. litellm has no per-value capability API (``get_supported_openai_params``
+    lists param names, not allowed values, and raises for ``whisper-1`` on the pinned
+    version), and internally distinguishes the two by model family too — so a family
+    check is the accepted approach here. Default stays the universally-safe ``json``.
+    """
+    return "whisper" in model.lower()
+
+
 def _resolve_api_base(provider: str) -> str | None:
     """Reuse the chat provider transport config so voice honors the same proxy."""
     cfg = get_provider_config(provider)
@@ -67,7 +79,9 @@ async def transcribe(
             file=(filename, audio_bytes),
             api_key=api_key,
             api_base=_resolve_api_base(provider),
-            response_format="verbose_json",
+            # Only Whisper accepts verbose_json (the source of language/duration);
+            # gpt-4o-transcribe* reject it and support json/text only.
+            response_format="verbose_json" if _supports_verbose_json(model) else "json",
         )
         return Transcript(
             text=response.text,

--- a/assemblix-app-api/tests/unit/external/test_voice_transcription.py
+++ b/assemblix-app-api/tests/unit/external/test_voice_transcription.py
@@ -44,6 +44,32 @@ async def test_whisper_route_returns_transcript_with_bare_model_id(mocker: Any) 
     assert atranscription.call_count == 1
     assert atranscription.call_args.kwargs["model"] == "whisper-1"
     assert atranscription.call_args.kwargs["api_key"] == "sk-test"
+    assert atranscription.call_args.kwargs["response_format"] == "verbose_json"
+
+
+async def test_gpt4o_transcribe_requests_json_format(mocker: Any) -> None:
+    """gpt-4o-transcribe rejects verbose_json, so the call must ask for plain json."""
+    # Arrange
+    fake_response = SimpleNamespace(text="hello world")
+    atranscription = mocker.patch(
+        "assemblix_api.external.voice.transcription.litellm.atranscription",
+        return_value=fake_response,
+    )
+
+    # Act
+    result = await transcribe(
+        audio_bytes=b"RIFFfake-wav-bytes",
+        filename="clip.webm",
+        provider="openai",
+        model="gpt-4o-transcribe",
+        api_key="sk-test",
+    )
+
+    # Assert
+    assert isinstance(result, Transcript)
+    assert result.text == "hello world"
+    assert result.language is None
+    assert atranscription.call_args.kwargs["response_format"] == "json"
 
 
 async def test_unregistered_model_raises_value_error(mocker: Any) -> None:


### PR DESCRIPTION
Чинит 500 на `POST /api/workflows/{id}/execute/debug/audio` при модели `gpt-4o-transcribe`. Было **две** первопричины, обе устранены.

## 1. `verbose_json` не поддерживается gpt-4o-transcribe (backend)

`external/voice/transcription.py` жёстко слал `response_format="verbose_json"` для всех transcription-моделей:

```
BadRequestError: response_format 'verbose_json' is not compatible with model
'gpt-4o-transcribe-api-ev3'. Use 'json' or 'text' instead.
```

`verbose_json` (источник `language`/`duration`) поддерживает только whisper. Фикс: формат выбирается по семейству модели — `verbose_json` для whisper, безопасный `json` для остального.

litellm не даёт нативной проверки допустимых *значений* `response_format` (`get_supported_openai_params` возвращает только имена параметров, а на запиненной `1.80.13` для `whisper-1` вообще бросает `ValueError`) и сам различает семейства по имени модели — так что family-check здесь и есть принятый подход.

## 2. WebM от MediaRecorder бракуется строгим валидатором gpt-4o (frontend)

После фикса №1 всплыл второй барьер:

```
BadRequestError: Audio file might be corrupted or unsupported
```

Браузерный `MediaRecorder` пишет streaming WebM/Opus с неполным заголовком (нет Duration/Cues). Строгий валидатор `gpt-4o-transcribe` такое отвергает; whisper-1 — терпел (поэтому дефолт работал). Серверного фикса без пересжатия контейнера нет.

Индустрия обходит это, генерируя корректный WAV **в браузере** (полный RIFF-заголовок проходит валидатор всегда) — без серверного ffmpeg. Пишем аудио сразу в WAV через `extendable-media-recorder` + `-wav-encoder` вместо нативного `MediaRecorder`. Кросс-браузерно (включая Safari, который webm вообще не пишет).

## Проверки

- Backend: `pytest tests/unit/external/test_voice_transcription.py` (3 passed, добавлен кейс `gpt-4o-transcribe` → `json`), ruff, mypy — зелёные.
- Frontend: `yarn build` (tsc + vite) и eslint по изменённому файлу — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)