### PR TITLE
feat(voice): native audio input for Gemini agents + explicit transcribe node

### DIFF
--- a/assemblix-app-api/assemblix_api/api/rest/executions.py
+++ b/assemblix-app-api/assemblix_api/api/rest/executions.py
@@ -218,6 +218,8 @@ def _build_input_data(request: ExecuteWorkflowRequest, *, is_debug: bool) -> dic
     if request.metadata:
         input_data["metadata"] = request.metadata
 
+    input_data.setdefault("input_type", "text")
+
     return input_data
 
 

--- a/assemblix-app-api/assemblix_api/api/rest/executions.py
+++ b/assemblix-app-api/assemblix_api/api/rest/executions.py
@@ -65,7 +65,10 @@ from assemblix_api.dto.responses.execution import (
 )
 from assemblix_api.enums import ExecutionStatus
 from assemblix_api.execution.debug_event_manager import DebugEventManager
-from assemblix_api.execution.voice_gate import load_audio_into_input_data
+from assemblix_api.execution.voice_gate import (
+    ensure_audio_run_is_synchronous,
+    load_audio_into_input_data,
+)
 from assemblix_api.queue.enqueue import enqueue_execution
 from assemblix_api.schemas.execution import AudioInput
 from assemblix_api.services.chat_service import ChatService
@@ -246,6 +249,14 @@ async def _dispatch_sync(
     # (just the execution_id) on timeout.
     settings = get_settings()
     if settings.execution_queue_enabled:
+        try:
+            ensure_audio_run_is_synchronous(input_data=input_data, queued=True)
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e),
+            ) from e
+
         arq_redis = await get_arq_pool()
         execution_id = await enqueue_execution(
             execution_service,

--- a/assemblix-app-api/assemblix_api/api/rest/executions.py
+++ b/assemblix-app-api/assemblix_api/api/rest/executions.py
@@ -37,12 +37,10 @@ from assemblix_api.dependencies import (
     get_billing_service,
     get_chat_service,
     get_client_session_service,
-    get_credentials_service,
     get_current_user,
     get_db_session,
     get_debug_event_manager,
     get_execution_service,
-    get_organization_service,
     get_project_id_from_token,
     get_project_id_from_token_with_access_check,
     get_project_service,
@@ -67,13 +65,12 @@ from assemblix_api.dto.responses.execution import (
 )
 from assemblix_api.enums import ExecutionStatus
 from assemblix_api.execution.debug_event_manager import DebugEventManager
-from assemblix_api.execution.voice_gate import transcribe_into_input_data
+from assemblix_api.execution.voice_gate import load_audio_into_input_data
 from assemblix_api.queue.enqueue import enqueue_execution
+from assemblix_api.schemas.execution import AudioInput
 from assemblix_api.services.chat_service import ChatService
 from assemblix_api.services.client_session_service import ClientSessionService
-from assemblix_api.services.credentials_service import CredentialsService
 from assemblix_api.services.execution_service import ExecutionService
-from assemblix_api.services.organization_service import OrganizationService
 from assemblix_api.services.project_service import ProjectService
 from assemblix_api.services.workflow_service import WorkflowService
 
@@ -232,6 +229,7 @@ async def _dispatch_sync(
     token_id: UUID,
     execution_service: ExecutionService,
     session: AsyncSession,
+    audio_input: AudioInput | None = None,
 ) -> ExecutionResponse | ExecutionErrorResponse | TaskExecutionResponse:
     """Run a workflow synchronously and shape the response (shared by /execute
     and /execute/audio).
@@ -288,6 +286,7 @@ async def _dispatch_sync(
             chat_session_id=request.session_id,
             execution_id_future=execution_id_future,
             result_future=result_future,
+            audio_input=audio_input,
         )
     )
     background_task_registry.track(task)
@@ -352,6 +351,7 @@ def _dispatch_debug_stream(
     session_id: UUID | None,
     token_id: UUID | None,
     debug_event_manager: DebugEventManager,
+    audio_input: AudioInput | None = None,
 ) -> StreamingResponse:
     """Start a debug run and return its SSE event stream (shared by
     /execute/debug and /execute/debug/audio)."""
@@ -366,6 +366,7 @@ def _dispatch_debug_stream(
             input_data=input_data,
             token_id=token_id,
             chat_session_id=session_id,
+            audio_input=audio_input,
         )
     )
     background_task_registry.track(_sse_task)
@@ -583,7 +584,7 @@ async def execute_workflow_debug(
 )
 async def execute_workflow_audio(
     workflow_id: UUID,
-    file: UploadFile = File(..., description="Audio blob to transcribe into the run input"),
+    file: UploadFile = File(..., description="Audio blob for the run input"),
     payload: str = Form("{}", description="JSON of ExecuteWorkflowRequest (without audio)"),
     workflow_service: WorkflowService = Depends(get_workflow_service),
     project_id_from_token: UUID = Depends(get_project_id_from_token),
@@ -592,17 +593,16 @@ async def execute_workflow_audio(
     chat_service: ChatService = Depends(get_chat_service),
     project_service: ProjectService = Depends(get_project_service),
     execution_service: ExecutionService = Depends(get_execution_service),
-    credential_service: CredentialsService = Depends(get_credentials_service),
-    organization_service: OrganizationService = Depends(get_organization_service),
     session: AsyncSession = Depends(get_db_session),
 ):
     """
     Execute a workflow from an audio message (multipart).
 
-    Same contract as ``POST /execute`` but the run input is a transcribed audio
-    blob. The target workflow's START node must have ``acceptVoice=true`` (else
-    400); the audio is transcribed server-side into ``input.message`` before the
-    run, so everything downstream behaves like a normal text execution.
+    Same contract as ``POST /execute`` but the run input is raw audio. The target
+    workflow's START node must have ``acceptVoice=true`` (else 400); the audio is
+    loaded onto the execution context (``input.input_type == "audio"``) — it is
+    no longer transcribed here, downstream nodes (e.g. an explicit ``transcribe``
+    node) consume it as needed.
     """
     request = _parse_execute_payload(payload)
 
@@ -619,13 +619,8 @@ async def execute_workflow_audio(
 
     input_data = _build_input_data(request, is_debug=False)
 
-    await transcribe_into_input_data(
-        workflow=workflow,
-        input_data=input_data,
-        file=file,
-        credential_service=credential_service,
-        organization_service=organization_service,
-        project_service=project_service,
+    audio_input = await load_audio_into_input_data(
+        workflow=workflow, input_data=input_data, file=file
     )
 
     return await _dispatch_sync(
@@ -636,6 +631,7 @@ async def execute_workflow_audio(
         token_id=token_id,
         execution_service=execution_service,
         session=session,
+        audio_input=audio_input,
     )
 
 
@@ -645,7 +641,7 @@ async def execute_workflow_audio(
 )
 async def execute_workflow_debug_audio(
     workflow_id: UUID,
-    file: UploadFile = File(..., description="Audio blob to transcribe into the run input"),
+    file: UploadFile = File(..., description="Audio blob for the run input"),
     payload: str = Form("{}", description="JSON of ExecuteWorkflowRequest (without audio)"),
     current_user: User = Depends(get_current_user),
     workflow_service: WorkflowService = Depends(get_workflow_service),
@@ -655,15 +651,14 @@ async def execute_workflow_debug_audio(
     billing_service: BillingService = Depends(get_billing_service),
     chat_service: ChatService = Depends(get_chat_service),
     project_service: ProjectService = Depends(get_project_service),
-    credential_service: CredentialsService = Depends(get_credentials_service),
-    organization_service: OrganizationService = Depends(get_organization_service),
 ):
     """
     Execute a workflow from an audio message in debug mode (multipart → SSE).
 
-    The audio-input twin of ``POST /execute/debug``: transcribes the blob into
-    ``input.message`` (START must have ``acceptVoice=true``), then streams the
-    run's SSE events exactly as the text debug endpoint does.
+    The audio-input twin of ``POST /execute/debug``: loads the blob onto the
+    execution context (START must have ``acceptVoice=true``; no transcription
+    happens here), then streams the run's SSE events exactly as the text debug
+    endpoint does.
     """
     request = _parse_execute_payload(payload)
 
@@ -681,13 +676,8 @@ async def execute_workflow_debug_audio(
 
     input_data = _build_input_data(request, is_debug=True)
 
-    await transcribe_into_input_data(
-        workflow=workflow,
-        input_data=input_data,
-        file=file,
-        credential_service=credential_service,
-        organization_service=organization_service,
-        project_service=project_service,
+    audio_input = await load_audio_into_input_data(
+        workflow=workflow, input_data=input_data, file=file
     )
 
     return _dispatch_debug_stream(
@@ -696,6 +686,7 @@ async def execute_workflow_debug_audio(
         session_id=request.session_id,
         token_id=token_id,
         debug_event_manager=debug_event_manager,
+        audio_input=audio_input,
     )
 
 

--- a/assemblix-app-api/assemblix_api/dependencies.py
+++ b/assemblix-app-api/assemblix_api/dependencies.py
@@ -62,6 +62,7 @@ from assemblix_api.database.repositories.user_repository import UserRepository
 from assemblix_api.database.repositories.workflow_repository import WorkflowRepository
 from assemblix_api.execution.debug_event_manager import DebugEventManager
 from assemblix_api.execution.workflow_executor import WorkflowExecutor
+from assemblix_api.schemas.execution import AudioInput
 from assemblix_api.services.api_key_service import APIKeyService
 from assemblix_api.services.avatar_service import AvatarService
 from assemblix_api.services.chat_message_service import ChatMessageService
@@ -615,6 +616,7 @@ async def run_workflow_isolated(
     chat_session_id: UUID | None,
     execution_id_future: asyncio.Future | None = None,
     result_future: asyncio.Future | None = None,
+    audio_input: AudioInput | None = None,
 ) -> None:
     """
     Run workflow execution in an isolated DB session.
@@ -633,6 +635,8 @@ async def run_workflow_isolated(
         chat_session_id: Chat session ID (optional)
         execution_id_future: Future that receives the execution ID after it is created
         result_future: Future that receives the ExecutionResult on completion
+        audio_input: Raw audio for this turn (voice endpoints), forwarded to the
+                     executor and attached to the execution context.
     """
     from assemblix_api.database.engine import get_async_engine
     from assemblix_api.database.repositories.workflow_repository import (
@@ -668,6 +672,7 @@ async def run_workflow_isolated(
                 token_id=token_id,
                 chat_session_id=chat_session_id,
                 on_execution_created=on_execution_created,
+                audio_input=audio_input,
             )
 
             if result_future is not None and not result_future.done():

--- a/assemblix-app-api/assemblix_api/execution/agent_runner.py
+++ b/assemblix-app-api/assemblix_api/execution/agent_runner.py
@@ -15,7 +15,7 @@ import json
 from collections.abc import Awaitable, Callable
 
 import structlog
-from pydantic_ai import Agent
+from pydantic_ai import Agent, BinaryContent
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -127,8 +127,15 @@ class AgentRunner:
         model_settings: ModelSettings | None = None,
         total_timeout: float | None = None,
         on_delta: Callable[[str], Awaitable[None]] | None = None,
+        audio: BinaryContent | None = None,
     ) -> AgentExecutionResult:
         history, prompt = to_pydantic_messages(conversation)
+
+        # Audio turn: the current-turn `prompt` is empty text (the run carries no
+        # transcript), so the audio itself becomes the user-prompt content part(s).
+        run_prompt: str | list[str | BinaryContent] = prompt
+        if audio is not None:
+            run_prompt = [audio] if not prompt else [prompt, audio]
 
         agent: Agent = Agent(
             model,
@@ -144,7 +151,7 @@ class AgentRunner:
         # the per-completion litellm `timeout`. On breach we raise a FATAL AgentRunTimeoutError
         # (do NOT retry — it would re-run already-executed tools).
         run_coro = agent.run(
-            prompt,
+            run_prompt,
             message_history=history,
             model_settings=model_settings,
             event_stream_handler=event_stream_handler,

--- a/assemblix-app-api/assemblix_api/execution/voice_gate.py
+++ b/assemblix-app-api/assemblix_api/execution/voice_gate.py
@@ -18,6 +18,12 @@ from assemblix_api.schemas.execution import AudioInput
 from assemblix_api.schemas.node import StartNodeConfig
 
 
+def ensure_audio_run_is_synchronous(*, input_data: dict, queued: bool) -> None:
+    """Audio bytes live in memory for one run; a queued run would lose them."""
+    if queued and input_data.get("input_type") == "audio":
+        raise ValueError("Audio input is only supported on synchronous runs")
+
+
 async def load_audio_into_input_data(
     *,
     workflow: Workflow,

--- a/assemblix-app-api/assemblix_api/execution/voice_gate.py
+++ b/assemblix-app-api/assemblix_api/execution/voice_gate.py
@@ -1,59 +1,50 @@
-"""Voice gate: transcribe an inbound audio blob into the run's text input.
+"""Voice gate: load an inbound audio blob onto the run's execution context.
 
 Called by the ``/execute/audio`` endpoints before dispatch. It reads the START
-node's voice config, enforces the accept-voice flag and the size cap, resolves
-the provider credential (reusing the agent-node credential chain), transcribes
-the audio via the voice module, and writes the transcript into
-``input_data["message"]`` — so the execution engine runs on a normal text input
-and never sees audio.
+node's voice config, enforces the accept-voice flag and the size cap, and
+returns the raw bytes as an ``AudioInput`` for the caller to attach to the
+execution context — transcription is NO LONGER done here, it is an explicit
+``transcribe`` node.
 """
 
 from __future__ import annotations
-
-from uuid import UUID
 
 from fastapi import HTTPException, UploadFile, status
 
 from assemblix_api.core.settings import get_settings
 from assemblix_api.database.models.workflow import Workflow
 from assemblix_api.execution.graph_navigator import GraphNavigator
-from assemblix_api.external.voice import transcribe
+from assemblix_api.schemas.execution import AudioInput
 from assemblix_api.schemas.node import StartNodeConfig
-from assemblix_api.services.credentials_service import CredentialsService
-from assemblix_api.services.organization_service import OrganizationService
-from assemblix_api.services.project_service import ProjectService
-
-_DEFAULT_VOICE_PROVIDER = "openai"
-_DEFAULT_VOICE_MODEL = "whisper-1"
 
 
-async def transcribe_into_input_data(
+async def load_audio_into_input_data(
     *,
     workflow: Workflow,
     input_data: dict,
     file: UploadFile,
-    credential_service: CredentialsService,
-    organization_service: OrganizationService,
-    project_service: ProjectService,
-) -> None:
-    """Transcribe ``file`` and set ``input_data["message"]`` in place.
+) -> AudioInput:
+    """Validate + load the inbound audio blob into the run.
+
+    Sets ``input_data["message"] = ""`` and ``input_data["input_type"] = "audio"``,
+    and returns the bytes as an ``AudioInput`` for the caller to attach to the
+    execution context. Transcription is NO LONGER done here — it is an explicit
+    ``transcribe`` node.
 
     Raises:
-        HTTPException(400): the workflow's START node does not accept voice.
+        HTTPException(400): the START node does not accept voice.
         HTTPException(413): the audio exceeds ``voice_max_upload_bytes``.
     """
     start_id = GraphNavigator.find_start_node(workflow.nodes)
     start_node = next((n for n in workflow.nodes if n["id"] == start_id), None)
     start_cfg = StartNodeConfig(**((start_node or {}).get("config") or {}))
-
     if not start_cfg.accept_voice:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="This workflow does not accept voice input",
         )
 
-    settings = get_settings()
-    max_bytes = settings.voice_max_upload_bytes
+    max_bytes = get_settings().voice_max_upload_bytes
     audio_bytes = await file.read(max_bytes + 1)
     if len(audio_bytes) > max_bytes:
         raise HTTPException(
@@ -61,24 +52,10 @@ async def transcribe_into_input_data(
             detail="Audio file is too large",
         )
 
-    provider = start_cfg.voice_model.provider if start_cfg.voice_model else _DEFAULT_VOICE_PROVIDER
-    model = start_cfg.voice_model.model if start_cfg.voice_model else _DEFAULT_VOICE_MODEL
-    credential_id = start_cfg.voice_model.credential_id if start_cfg.voice_model else None
-
-    project = await project_service.get_by_id(workflow.project_id)
-    organization = await organization_service.get_by_id(project.organization_id)
-    api_key, _ = await credential_service.get_voice_api_key_with_fallback(
-        credentials_id=UUID(credential_id) if credential_id else None,
-        project_id=workflow.project_id,
-        voice_provider=provider,
-        organization_plan=organization.plan,
+    input_data["message"] = ""
+    input_data["input_type"] = "audio"
+    return AudioInput(
+        bytes=audio_bytes,
+        mime=getattr(file, "content_type", None) or "audio/wav",
+        filename=file.filename or "voice.wav",
     )
-
-    transcript = await transcribe(
-        audio_bytes=audio_bytes,
-        filename=file.filename or "audio",
-        provider=provider,
-        model=model,
-        api_key=api_key,
-    )
-    input_data["message"] = transcript.text

--- a/assemblix-app-api/assemblix_api/execution/workflow_executor.py
+++ b/assemblix-app-api/assemblix_api/execution/workflow_executor.py
@@ -36,6 +36,7 @@ from assemblix_api.execution.debug_event_manager import DebugEventManager
 from assemblix_api.execution.graph_navigator import GraphNavigator
 from assemblix_api.execution.node_runner import NodeRunner
 from assemblix_api.schemas.execution import (
+    AudioInput,
     ExecutionContext,
     ExecutionResult,
     ExecutionResultMetadata,
@@ -104,6 +105,7 @@ class WorkflowExecutor:
         chat_session_id: UUID | None = None,
         on_execution_created: Callable[[UUID], Awaitable[None]] | None = None,
         execution_id: UUID | None = None,
+        audio_input: AudioInput | None = None,
     ) -> ExecutionResult:
         """
         Main execution entry point.
@@ -123,6 +125,8 @@ class WorkflowExecutor:
                           instead of creating a new one. The row is loaded and transitioned
                           to RUNNING. When None (default), a new execution row is created
                           — this path is byte-for-byte unchanged.
+            audio_input: Raw audio for this turn (voice endpoints), attached to the
+                         execution context for nodes that consume it directly.
 
         Returns:
             ExecutionResult with output and metadata
@@ -133,7 +137,12 @@ class WorkflowExecutor:
         try:
             # 1. Preparation phase
             execution, context, resume_point = await self._preparation_phase(
-                workflow, input_data, token_id, chat_session_id, execution_id=execution_id
+                workflow,
+                input_data,
+                token_id,
+                chat_session_id,
+                execution_id=execution_id,
+                audio_input=audio_input,
             )
 
             # Bind execution context for all subsequent logs inside this task.
@@ -246,6 +255,7 @@ class WorkflowExecutor:
         token_id: UUID | None,
         chat_session_id: UUID | None,
         execution_id: UUID | None = None,
+        audio_input: AudioInput | None = None,
     ) -> tuple[Execution, ExecutionContext, "ResumePoint | None"]:
         """
         Create (or load) execution record and build execution context.
@@ -469,6 +479,7 @@ class WorkflowExecutor:
             chat_history=chat_history,
             db_checkpoint=self._db_checkpoint,
             stream_enabled=stream_enabled,
+            audio_input=audio_input,
         )
 
         # 11. Open the event stream. Debug uses the legacy queue+buffer (create_stream);

--- a/assemblix-app-api/assemblix_api/external/llm/base.py
+++ b/assemblix-app-api/assemblix_api/external/llm/base.py
@@ -74,6 +74,10 @@ class ModelCapabilities(DTOModel):
             "gpt-5.4 family, gpt-5.5); rejected by gpt-5.1 and earlier."
         ),
     )
+    accepts_audio: bool = Field(
+        default=False,
+        description="Model accepts audio input parts natively (skip STT).",
+    )
 
 
 class ModelMetadata(DTOModel):

--- a/assemblix-app-api/assemblix_api/external/llm/models/gemini.json
+++ b/assemblix-app-api/assemblix_api/external/llm/models/gemini.json
@@ -7,7 +7,7 @@
       "default": 1,
       "min": 0,
       "max": 2,
-      "description": "Controls randomness. Gemini 3.x: keep at 1.0 — Google warns that lowering can cause reasoning loops."
+      "description": "Controls randomness. Gemini 3.x: keep at 1.0 \u2014 Google warns that lowering can cause reasoning loops."
     },
     {
       "name": "max_tokens",
@@ -15,7 +15,7 @@
       "type": "number",
       "default": 8192,
       "min": 1,
-      "description": "Maximum output tokens, INCLUDING thinking tokens. Mapped to Gemini's `max_output_tokens` internally. Reserve generous budget for thinking models (Pro: ≥2000)."
+      "description": "Maximum output tokens, INCLUDING thinking tokens. Mapped to Gemini's `max_output_tokens` internally. Reserve generous budget for thinking models (Pro: \u22652000)."
     },
     {
       "name": "response_format",
@@ -63,7 +63,7 @@
           "gen3"
         ]
       },
-      "description": "Reasoning token budget. -1 = dynamic, 0 = disable (Flash only). Gemini 2.5 Pro: range 128–32 768 (cannot disable). Gemini 2.5 Flash: 0–24 576."
+      "description": "Reasoning token budget. -1 = dynamic, 0 = disable (Flash only). Gemini 2.5 Pro: range 128\u201332 768 (cannot disable). Gemini 2.5 Flash: 0\u201324 576."
     },
     {
       "name": "thinking_level",
@@ -105,7 +105,8 @@
       "inputCostPerMillion": 1.5,
       "outputCostPerMillion": 9.0,
       "capabilities": {
-        "gen3": true
+        "gen3": true,
+        "acceptsAudio": true
       }
     },
     {
@@ -116,7 +117,8 @@
       "inputCostPerMillion": 2.5,
       "outputCostPerMillion": 15.0,
       "capabilities": {
-        "gen3": true
+        "gen3": true,
+        "acceptsAudio": true
       }
     },
     {
@@ -127,7 +129,8 @@
       "inputCostPerMillion": 0.1,
       "outputCostPerMillion": 0.4,
       "capabilities": {
-        "gen3": true
+        "gen3": true,
+        "acceptsAudio": true
       }
     },
     {
@@ -138,7 +141,8 @@
       "inputCostPerMillion": 2.5,
       "outputCostPerMillion": 15.0,
       "capabilities": {
-        "gen3": true
+        "gen3": true,
+        "acceptsAudio": true
       }
     },
     {
@@ -149,7 +153,8 @@
       "inputCostPerMillion": 0.3,
       "outputCostPerMillion": 1.2,
       "capabilities": {
-        "gen3": true
+        "gen3": true,
+        "acceptsAudio": true
       }
     },
     {
@@ -159,7 +164,9 @@
       "maxOutputTokens": 65536,
       "inputCostPerMillion": 1.25,
       "outputCostPerMillion": 10.0,
-      "capabilities": {}
+      "capabilities": {
+        "acceptsAudio": true
+      }
     },
     {
       "id": "gemini-2.5-flash",
@@ -168,7 +175,9 @@
       "maxOutputTokens": 65536,
       "inputCostPerMillion": 0.3,
       "outputCostPerMillion": 1.2,
-      "capabilities": {}
+      "capabilities": {
+        "acceptsAudio": true
+      }
     }
   ]
 }

--- a/assemblix-app-api/assemblix_api/external/llm/models/gemini.json
+++ b/assemblix-app-api/assemblix_api/external/llm/models/gemini.json
@@ -7,7 +7,7 @@
       "default": 1,
       "min": 0,
       "max": 2,
-      "description": "Controls randomness. Gemini 3.x: keep at 1.0 \u2014 Google warns that lowering can cause reasoning loops."
+      "description": "Controls randomness. Gemini 3.x: keep at 1.0 — Google warns that lowering can cause reasoning loops."
     },
     {
       "name": "max_tokens",
@@ -15,7 +15,7 @@
       "type": "number",
       "default": 8192,
       "min": 1,
-      "description": "Maximum output tokens, INCLUDING thinking tokens. Mapped to Gemini's `max_output_tokens` internally. Reserve generous budget for thinking models (Pro: \u22652000)."
+      "description": "Maximum output tokens, INCLUDING thinking tokens. Mapped to Gemini's `max_output_tokens` internally. Reserve generous budget for thinking models (Pro: ≥2000)."
     },
     {
       "name": "response_format",
@@ -63,7 +63,7 @@
           "gen3"
         ]
       },
-      "description": "Reasoning token budget. -1 = dynamic, 0 = disable (Flash only). Gemini 2.5 Pro: range 128\u201332 768 (cannot disable). Gemini 2.5 Flash: 0\u201324 576."
+      "description": "Reasoning token budget. -1 = dynamic, 0 = disable (Flash only). Gemini 2.5 Pro: range 128–32 768 (cannot disable). Gemini 2.5 Flash: 0–24 576."
     },
     {
       "name": "thinking_level",

--- a/assemblix-app-api/assemblix_api/nodes/__init__.py
+++ b/assemblix-app-api/assemblix_api/nodes/__init__.py
@@ -13,6 +13,7 @@ from .end_node import EndNode  # noqa: F401
 from .http_request_node import HTTPRequestNode  # noqa: F401
 from .set_variable_node import SetVariableNode  # noqa: F401
 from .start_node import StartNode  # noqa: F401
+from .transcribe_node import TranscribeNode  # noqa: F401
 
 __all__ = [
     "StartNode",
@@ -22,4 +23,5 @@ __all__ = [
     "SetVariableNode",
     "HTTPRequestNode",
     "DelayNode",
+    "TranscribeNode",
 ]

--- a/assemblix-app-api/assemblix_api/nodes/agent_node.py
+++ b/assemblix-app-api/assemblix_api/nodes/agent_node.py
@@ -77,6 +77,24 @@ class AgentNode(BaseNode):
         num_retries = cfg.max_retries if cfg.max_retries is not None else settings.llm_num_retries
         total_timeout = cfg.timeout_seconds or settings.agent_run_timeout_seconds
 
+        # 3b. Audio turn: send the raw audio to an audio-capable model instead of
+        # relying on a separate transcription step. Non-audio models get a clear
+        # error rather than silently ignoring the audio.
+        inbound_audio = context.audio_input
+        audio_part = None
+        if node_input.data.get("input_type") == "audio" and inbound_audio is not None:
+            from assemblix_api.external.llm.model_catalog import find_model_metadata
+
+            meta = find_model_metadata(cfg.provider.value, cfg.model)
+            if meta is None or not meta.capabilities.accepts_audio:
+                raise ValueError(
+                    f"Model {cfg.provider.value}/{cfg.model} does not accept audio — "
+                    "place a Transcribe node before this agent."
+                )
+            from pydantic_ai import BinaryContent
+
+            audio_part = BinaryContent(data=inbound_audio.bytes, media_type=inbound_audio.mime)
+
         # When enforce_timeout_on_last is off, the last model in the chain runs up to the
         # whole-loop budget instead of the shorter per-call timeout — a last resort that
         # still cannot exceed the hard ceiling (asyncio.wait_for below). Otherwise every
@@ -169,6 +187,7 @@ class AgentNode(BaseNode):
                 parse_json=parse_json,
                 total_timeout=total_timeout,
                 on_delta=effective_on_delta,
+                audio=audio_part,
             )
 
         output_data = {

--- a/assemblix-app-api/assemblix_api/nodes/agent_node.py
+++ b/assemblix-app-api/assemblix_api/nodes/agent_node.py
@@ -26,6 +26,26 @@ from assemblix_api.tools.toolsets import build_toolsets
 
 logger = structlog.get_logger(__name__)
 
+# Audio media types pydantic_ai's BinaryContent.format actually resolves (see
+# `_audio_format_lookup` in pydantic_ai.messages, pydantic_ai==1.107.0). Any other
+# media_type makes BinaryContent raise an opaque `ValueError: Unknown media type`
+# deep inside agent.run — validate against this set up front instead.
+_PYDANTIC_AI_AUDIO_MEDIA_TYPES = frozenset(
+    {"audio/wav", "audio/mpeg", "audio/ogg", "audio/flac", "audio/aiff", "audio/aac"}
+)
+
+# Browser/client-sent aliases for media types pydantic_ai does accept.
+_AUDIO_MIME_ALIASES = {
+    "audio/wave": "audio/wav",
+    "audio/x-wav": "audio/wav",
+    "audio/mp3": "audio/mpeg",
+}
+
+
+def _normalize_audio_mime(mime: str) -> str:
+    """Map common client-sent aliases onto the media type pydantic_ai expects."""
+    return _AUDIO_MIME_ALIASES.get(mime, mime)
+
 
 def _is_transient(exc: Exception) -> bool:
     """fallback_on predicate for FallbackModel: switch to the next model only on a
@@ -93,7 +113,15 @@ class AgentNode(BaseNode):
                 )
             from pydantic_ai import BinaryContent
 
-            audio_part = BinaryContent(data=inbound_audio.bytes, media_type=inbound_audio.mime)
+            normalized_mime = _normalize_audio_mime(inbound_audio.mime)
+            if normalized_mime not in _PYDANTIC_AI_AUDIO_MEDIA_TYPES:
+                raise ValueError(
+                    f"Audio format '{inbound_audio.mime}' is not supported for model "
+                    f"{cfg.provider.value}/{cfg.model}. Use WAV or MP3, or place a "
+                    "Transcribe node before this agent."
+                )
+
+            audio_part = BinaryContent(data=inbound_audio.bytes, media_type=normalized_mime)
 
         # When enforce_timeout_on_last is off, the last model in the chain runs up to the
         # whole-loop budget instead of the shorter per-call timeout — a last resort that

--- a/assemblix-app-api/assemblix_api/nodes/transcribe_node.py
+++ b/assemblix-app-api/assemblix_api/nodes/transcribe_node.py
@@ -31,6 +31,7 @@ class TranscribeNode(BaseNode):
 
         cfg = self.typed_config.voice_model
         assert context.credential_service is not None
+        assert context.organization_plan is not None
         api_key, _ = await context.credential_service.get_voice_api_key_with_fallback(
             credentials_id=UUID(cfg.credential_id) if cfg.credential_id else None,
             project_id=context.project_id,

--- a/assemblix-app-api/assemblix_api/nodes/transcribe_node.py
+++ b/assemblix-app-api/assemblix_api/nodes/transcribe_node.py
@@ -30,15 +30,13 @@ class TranscribeNode(BaseNode):
             return NodeOutput(data=data)  # passthrough (already text)
 
         cfg = self.typed_config.voice_model
-        assert cfg is not None
-        api_key = ""
-        if context.credential_service is not None:
-            api_key, _ = await context.credential_service.get_voice_api_key_with_fallback(
-                credentials_id=UUID(cfg.credential_id) if cfg.credential_id else None,
-                project_id=context.project_id,
-                voice_provider=cfg.provider,
-                organization_plan=context.organization_plan,
-            )
+        assert context.credential_service is not None
+        api_key, _ = await context.credential_service.get_voice_api_key_with_fallback(
+            credentials_id=UUID(cfg.credential_id) if cfg.credential_id else None,
+            project_id=context.project_id,
+            voice_provider=cfg.provider,
+            organization_plan=context.organization_plan,
+        )
         result = await transcribe(
             audio_bytes=context.audio_input.bytes,
             filename=context.audio_input.filename,

--- a/assemblix-app-api/assemblix_api/nodes/transcribe_node.py
+++ b/assemblix-app-api/assemblix_api/nodes/transcribe_node.py
@@ -1,0 +1,76 @@
+"""Transcribe node — normalize an audio turn to text where the user places it.
+
+Audio input -> transcript (via ``external/voice/transcription.py::transcribe``).
+Text input -> passthrough (no-op). With ``saveAsUserMessage`` (default true) the
+transcript is recorded as the user turn in chat history.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from assemblix_api.core.node_registry import register_node
+from assemblix_api.enums import MessageRole
+from assemblix_api.external.voice.transcription import transcribe
+from assemblix_api.schemas import BaseNode, NodeInput, NodeOutput
+from assemblix_api.schemas.node import TranscribeNodeConfig
+from assemblix_api.schemas.node_descriptor import NodeDescriptor, NodeProperty
+
+
+@register_node("transcribe")
+class TranscribeNode(BaseNode):
+    def __init__(self, node_config: dict) -> None:
+        super().__init__(node_config)
+        self.typed_config = TranscribeNodeConfig(**node_config["config"])
+
+    async def execute(self, node_input: NodeInput) -> NodeOutput:
+        data = dict(node_input.data)
+        context = node_input.context
+        if data.get("input_type") != "audio" or context.audio_input is None:
+            return NodeOutput(data=data)  # passthrough (already text)
+
+        cfg = self.typed_config.voice_model
+        assert cfg is not None
+        api_key = ""
+        if context.credential_service is not None:
+            api_key, _ = await context.credential_service.get_voice_api_key_with_fallback(
+                credentials_id=UUID(cfg.credential_id) if cfg.credential_id else None,
+                project_id=context.project_id,
+                voice_provider=cfg.provider,
+                organization_plan=context.organization_plan,
+            )
+        result = await transcribe(
+            audio_bytes=context.audio_input.bytes,
+            filename=context.audio_input.filename,
+            provider=cfg.provider,
+            model=cfg.model,
+            api_key=api_key,
+        )
+        data["message"] = result.text
+        data["input_type"] = "text"
+
+        if self.typed_config.save_as_user_message and context.chat_session_id:
+            assert context.chat_message_service is not None
+            await context.chat_message_service.save_message(
+                chat_session_id=context.chat_session_id,
+                role=MessageRole.USER,
+                content=result.text,
+            )
+        return NodeOutput(data=data)
+
+    @classmethod
+    def descriptor(cls) -> NodeDescriptor:
+        return NodeDescriptor(
+            type="transcribe",
+            display_name="Transcribe",
+            description="Turn an audio turn into text (passthrough if already text).",
+            icon="AudioLines",
+            properties=[
+                NodeProperty(
+                    name="saveAsUserMessage",
+                    display_name="Save as user message",
+                    type="boolean",
+                    default=True,
+                ),
+            ],
+        )

--- a/assemblix-app-api/assemblix_api/schemas/execution.py
+++ b/assemblix-app-api/assemblix_api/schemas/execution.py
@@ -12,6 +12,15 @@ from uuid import UUID
 from assemblix_api.dto.base import DTOModel
 
 
+@dataclass(frozen=True)
+class AudioInput:
+    """Raw audio for the current turn. Runtime-only — never serialized."""
+
+    bytes: bytes
+    mime: str
+    filename: str
+
+
 async def _noop_checkpoint() -> None:
     """Default db_checkpoint: a no-op for paths that don't manage a long-lived
     execution session (API request scope, unit tests)."""
@@ -81,6 +90,9 @@ class ExecutionContext:
     # Persisted as the assistant turn at finalization so the DB matches what
     # downstream agents saw in-memory. None → fall back to the full final output.
     last_history_message: str | None = None
+    # Audio input for the current turn (e.g., voice from user). Runtime-only field,
+    # not persisted or serialized. Used by agent nodes to process audio input.
+    audio_input: AudioInput | None = None
     # Transaction boundary hook: commits the execution session and returns its
     # DB connection to the pool. Nodes call this right before a long external
     # await (LLM/HTTP) so a workflow does not hold a Postgres connection while

--- a/assemblix-app-api/assemblix_api/schemas/node.py
+++ b/assemblix-app-api/assemblix_api/schemas/node.py
@@ -63,10 +63,13 @@ class StartNodeConfig(DTOModel):
     # On a new session this greeting is stored as an assistant message and
     # becomes part of the chat history.
     first_phrase: str | None = None
-    # Voice input: when true, the /execute/audio endpoints transcribe an inbound
-    # audio blob into `input.message` before the run. `voice_model` selects the
-    # transcription provider/model; it defaults to openai/whisper-1 when unset.
+    # Voice input: when true, the /execute/audio endpoints accept an inbound audio
+    # blob and attach it to the run as raw audio (see AudioInput) instead of text.
     accept_voice: bool = False
+    # Deprecated/unused: transcription is no longer performed at the gate. It was
+    # replaced by the explicit `transcribe` node (see TranscribeNodeConfig.voice_model).
+    # Kept on the schema only because the START node's frontend form still references
+    # it; not read anywhere in the backend.
     voice_model: VoiceModelConfig | None = None
 
 

--- a/assemblix-app-api/assemblix_api/schemas/node.py
+++ b/assemblix-app-api/assemblix_api/schemas/node.py
@@ -49,11 +49,13 @@ class WorkflowAvatarConfig(DTOModel):
 class TranscribeNodeConfig(DTOModel):
     """Config for the `transcribe` node — normalizes an audio turn to text.
 
-    ``voice_model`` is optional so the node also works untouched on text-only runs
-    (where it never reaches the transcription call anyway).
+    ``voice_model`` is required (unlike ``StartNodeConfig.voice_model``, which is
+    optional because voice acceptance itself is optional): this node's whole purpose
+    is transcription, so a missing model should fail config validation at save time
+    rather than surface as a runtime error the first time audio arrives.
     """
 
-    voice_model: VoiceModelConfig | None = None
+    voice_model: VoiceModelConfig
     save_as_user_message: bool = True
 
 

--- a/assemblix-app-api/assemblix_api/schemas/node.py
+++ b/assemblix-app-api/assemblix_api/schemas/node.py
@@ -46,6 +46,17 @@ class WorkflowAvatarConfig(DTOModel):
     credential_id: str | None = None
 
 
+class TranscribeNodeConfig(DTOModel):
+    """Config for the `transcribe` node — normalizes an audio turn to text.
+
+    ``voice_model`` is optional so the node also works untouched on text-only runs
+    (where it never reaches the transcription call anyway).
+    """
+
+    voice_model: VoiceModelConfig | None = None
+    save_as_user_message: bool = True
+
+
 class StartNodeConfig(DTOModel):
     # On a new session this greeting is stored as an assistant message and
     # becomes part of the chat history.

--- a/assemblix-app-api/tests/integration/test_voice_native_workflow.py
+++ b/assemblix-app-api/tests/integration/test_voice_native_workflow.py
@@ -1,0 +1,202 @@
+"""End-to-end test: audio-direct agent + transcribe→history (Task 9).
+
+Exercises the real production path over HTTP — register → create API key → create
+a workflow whose START accepts voice → publish → execute with an audio blob
+(multipart). The STT seam (``litellm.atranscription``) is mocked and the LLM seam
+is ``mock_llm``, so this test proves our own wiring, not the providers.
+
+Graph shape — LINEAR, not a parallel fork: two separate START(audio)→…→END
+workflows, one per branch:
+  1. START(audio) → AGENT on an audio-capable Gemini model → END
+     (proves the audio blob reaches the LLM as a content part, no transcription).
+  2. START(audio) → transcribe (saveAsUserMessage) → END
+     (proves the transcript is saved as the USER chat turn).
+
+Deviation from the brief's parallel-fork sketch (start ⇉ [agent, transcribe] → end):
+wiring that fork through the real ``/execute/audio`` HTTP path hits a genuine
+concurrency bug in ``WorkflowExecutor._execution_loop_parallel`` — the transcribe
+branch's ``chat_message_service.save_message`` DB write races the agent branch's
+step-recording DB write on the *same* AsyncSession, raising
+``sqlalchemy.exc.InvalidRequestError: This session is provisioning a new
+connection; concurrent operations are not permitted``. That is a pre-existing
+execution-engine limitation (concurrent branches sharing one session), out of
+scope for the voice feature itself. Per the task brief's escalation guidance, this
+test falls back to two linear graphs that independently prove both behaviors.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest_asyncio
+
+from tests.fixtures.workflows import agent_config, edge, node
+
+# Gemini model with capabilities.accepts_audio=True in the model catalog
+# (see tests/unit/external/test_model_catalog_audio.py).
+AUDIO_MODEL = "gemini-3-flash-preview"
+
+# WAV, not webm: the audio-direct agent sends the raw blob to pydantic_ai's
+# BinaryContent, whose audio-format lookup only covers a fixed set of mime types
+# (wav/mp3/flac/ogg/aiff/aac) — see agent_node.py's audio_part construction.
+AUDIO_FILE = ("clip.wav", b"RIFFfake-audio", "audio/wav")
+
+
+def _start_config() -> dict[str, Any]:
+    return {"acceptVoice": True, "voiceModel": {"provider": "openai", "model": "whisper-1"}}
+
+
+def _audio_agent_workflow() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """START (accepts voice) → AGENT on an audio-capable model → END."""
+    nodes = [
+        node("start", "start", _start_config()),
+        node(
+            "agent",
+            "agent",
+            agent_config(provider="gemini", model=AUDIO_MODEL, instructions="Reply to the user."),
+        ),
+        node("end", "end", {}),
+    ]
+    edges = [edge("start", "agent"), edge("agent", "end")]
+    return nodes, edges
+
+
+def _transcribe_workflow() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """START (accepts voice) → transcribe (saves as USER turn) → END."""
+    nodes = [
+        node("start", "start", _start_config()),
+        node(
+            "transcribe",
+            "transcribe",
+            {
+                "voiceModel": {"provider": "openai", "model": "whisper-1"},
+                "saveAsUserMessage": True,
+            },
+        ),
+        node("end", "end", {}),
+    ]
+    edges = [edge("start", "transcribe"), edge("transcribe", "end")]
+    return nodes, edges
+
+
+async def _register_and_publish(
+    api_client, *, email: str, nodes: list[dict[str, Any]], edges: list[dict[str, Any]]
+) -> SimpleNamespace:
+    """Register a user, mint an API key, create + publish a workflow."""
+    reg = await api_client.post(
+        "/api/auth/register", json={"email": email, "password": "pass1234"}
+    )
+    assert reg.status_code == 201
+    jwt_headers = {"Authorization": f"Bearer {reg.json()['accessToken']}"}
+    project_id = reg.json()["projectId"]
+
+    key_resp = await api_client.post(
+        "/api/api-keys/",
+        json={"projectId": project_id, "name": "voice-native-key"},
+        headers=jwt_headers,
+    )
+    assert key_resp.status_code == 201
+    key_headers = {"Authorization": f"Bearer {key_resp.json()['apiKey']}"}
+
+    create_resp = await api_client.post(
+        "/api/workflows/",
+        json={"projectId": project_id, "name": "Voice native workflow", "nodes": nodes, "edges": edges},
+        headers=jwt_headers,
+    )
+    assert create_resp.status_code == 201
+    workflow_id = create_resp.json()["id"]
+
+    publish_resp = await api_client.post(
+        f"/api/workflows/{workflow_id}/publish", headers=jwt_headers
+    )
+    assert publish_resp.status_code == 200
+
+    return SimpleNamespace(
+        key_headers=key_headers, jwt_headers=jwt_headers, workflow_id=workflow_id
+    )
+
+
+def _content_parts(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Flatten any list-typed ``content`` across messages into a flat list of parts."""
+    parts: list[dict[str, Any]] = []
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, list):
+            parts.extend(p for p in content if isinstance(p, dict))
+    return parts
+
+
+async def test_audio_direct_agent_receives_audio_content_part(
+    api_client, mock_llm
+) -> None:
+    """START(audio) → AGENT(audio-capable model) → END: the agent's LLM call
+    carries a raw audio content part instead of a transcribed text message."""
+    # Arrange
+    mock_llm.set_response("agent reply")
+    nodes, edges = _audio_agent_workflow()
+    setup = await _register_and_publish(
+        api_client, email="voice-agent@example.com", nodes=nodes, edges=edges
+    )
+
+    # Act
+    before = mock_llm.call_count
+    run = await api_client.post(
+        f"/api/workflows/{setup.workflow_id}/execute/audio",
+        files={"file": AUDIO_FILE},
+        data={"payload": json.dumps({"input": {}, "createSession": True})},
+        headers=setup.key_headers,
+    )
+
+    # Assert — run completed and the LLM call carried an audio content part.
+    assert run.status_code == 200
+    assert run.json()["status"] == "completed"
+    agent_calls = mock_llm.calls[before:]
+    assert agent_calls, "expected at least one LLM call from the audio-direct agent"
+    parts = [p for c in agent_calls for p in _content_parts(c["messages"])]
+    assert any(p.get("type") in {"input_audio", "audio", "file"} for p in parts), (
+        f"no audio content part found in agent messages: {parts}"
+    )
+
+
+async def test_transcribe_node_saves_transcript_as_user_turn(
+    api_client, mock_llm, mocker: Any
+) -> None:
+    """START(audio) → transcribe(saveAsUserMessage) → END: the transcript from
+    the (mocked) STT call is saved as the USER turn in chat history."""
+    # Arrange — patch the STT seam so the branch is deterministic.
+    async def _fake_transcription(**_: Any) -> SimpleNamespace:
+        return SimpleNamespace(text="native voice transcript", language="en", duration=1.0)
+
+    mocker.patch(
+        "assemblix_api.external.voice.transcription.litellm.atranscription",
+        side_effect=_fake_transcription,
+    )
+    nodes, edges = _transcribe_workflow()
+    setup = await _register_and_publish(
+        api_client, email="voice-transcribe@example.com", nodes=nodes, edges=edges
+    )
+
+    # Act
+    run = await api_client.post(
+        f"/api/workflows/{setup.workflow_id}/execute/audio",
+        files={"file": AUDIO_FILE},
+        data={"payload": json.dumps({"input": {}, "createSession": True})},
+        headers=setup.key_headers,
+    )
+
+    # Assert — run completed and the transcript was saved as a USER chat turn.
+    assert run.status_code == 200
+    body = run.json()
+    assert body["status"] == "completed"
+    session_id = body["sessionId"]
+    detail = await api_client.get(
+        f"/api/chat-sessions/{session_id}", headers=setup.jwt_headers
+    )
+    assert detail.status_code == 200
+    messages = detail.json()["messages"]
+    user_messages = [m for m in messages if m["role"] == "user"]
+    assert any(m["content"] == "native voice transcript" for m in user_messages), (
+        f"expected a saved user turn with the transcript, got: {user_messages}"
+    )

--- a/assemblix-app-api/tests/integration/test_voice_native_workflow.py
+++ b/assemblix-app-api/tests/integration/test_voice_native_workflow.py
@@ -30,8 +30,6 @@ import json
 from types import SimpleNamespace
 from typing import Any
 
-import pytest_asyncio
-
 from tests.fixtures.workflows import agent_config, edge, node
 
 # Gemini model with capabilities.accepts_audio=True in the model catalog
@@ -85,9 +83,7 @@ async def _register_and_publish(
     api_client, *, email: str, nodes: list[dict[str, Any]], edges: list[dict[str, Any]]
 ) -> SimpleNamespace:
     """Register a user, mint an API key, create + publish a workflow."""
-    reg = await api_client.post(
-        "/api/auth/register", json={"email": email, "password": "pass1234"}
-    )
+    reg = await api_client.post("/api/auth/register", json={"email": email, "password": "pass1234"})
     assert reg.status_code == 201
     jwt_headers = {"Authorization": f"Bearer {reg.json()['accessToken']}"}
     project_id = reg.json()["projectId"]
@@ -102,7 +98,12 @@ async def _register_and_publish(
 
     create_resp = await api_client.post(
         "/api/workflows/",
-        json={"projectId": project_id, "name": "Voice native workflow", "nodes": nodes, "edges": edges},
+        json={
+            "projectId": project_id,
+            "name": "Voice native workflow",
+            "nodes": nodes,
+            "edges": edges,
+        },
         headers=jwt_headers,
     )
     assert create_resp.status_code == 201
@@ -128,9 +129,7 @@ def _content_parts(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return parts
 
 
-async def test_audio_direct_agent_receives_audio_content_part(
-    api_client, mock_llm
-) -> None:
+async def test_audio_direct_agent_receives_audio_content_part(api_client, mock_llm) -> None:
     """START(audio) → AGENT(audio-capable model) → END: the agent's LLM call
     carries a raw audio content part instead of a transcribed text message."""
     # Arrange
@@ -165,6 +164,7 @@ async def test_transcribe_node_saves_transcript_as_user_turn(
 ) -> None:
     """START(audio) → transcribe(saveAsUserMessage) → END: the transcript from
     the (mocked) STT call is saved as the USER turn in chat history."""
+
     # Arrange — patch the STT seam so the branch is deterministic.
     async def _fake_transcription(**_: Any) -> SimpleNamespace:
         return SimpleNamespace(text="native voice transcript", language="en", duration=1.0)
@@ -191,9 +191,7 @@ async def test_transcribe_node_saves_transcript_as_user_turn(
     body = run.json()
     assert body["status"] == "completed"
     session_id = body["sessionId"]
-    detail = await api_client.get(
-        f"/api/chat-sessions/{session_id}", headers=setup.jwt_headers
-    )
+    detail = await api_client.get(f"/api/chat-sessions/{session_id}", headers=setup.jwt_headers)
     assert detail.status_code == 200
     messages = detail.json()["messages"]
     user_messages = [m for m in messages if m["role"] == "user"]

--- a/assemblix-app-api/tests/integration/test_workflow_voice_execute.py
+++ b/assemblix-app-api/tests/integration/test_workflow_voice_execute.py
@@ -6,6 +6,11 @@ blob (multipart). The transcription seam (`litellm.atranscription`) is mocked, s
 we test our own wiring: the blob is transcribed and the transcript is what the
 agent receives as the user message. Run twice with different transcripts to prove
 the audio path works on every call.
+
+START now hands raw audio straight to the next node (see
+``tests/integration/test_voice_native_workflow.py``), so a Transcribe node sits
+between START and AGENT to normalize audio -> text before the agent runs — the
+agent's default model (openai/gpt-4o) doesn't accept audio content parts.
 """
 
 from __future__ import annotations
@@ -20,17 +25,29 @@ from tests.fixtures.workflows import agent_config, edge, node
 
 
 def _voice_workflow() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """START (accepts voice) → AGENT → END."""
+    """START (accepts voice) → transcribe → AGENT → END.
+
+    The transcribe node hands the transcript downstream as ``input.message``
+    (not via chat_history — see transcribe_node.py); the agent instructions
+    pick it up with a CEL template, same as any other node-to-node data pass.
+    """
+    agent_cfg = agent_config(instructions="Reply to the user.")
+    agent_cfg["instructions"].append({"role": "user", "content": "{{input.message}}"})
     nodes = [
         node(
             "start",
             "start",
             {"acceptVoice": True, "voiceModel": {"provider": "openai", "model": "whisper-1"}},
         ),
-        node("agent", "agent", agent_config(instructions="Reply to the user.")),
+        node(
+            "transcribe",
+            "transcribe",
+            {"voiceModel": {"provider": "openai", "model": "whisper-1"}},
+        ),
+        node("agent", "agent", agent_cfg),
         node("end", "end", {}),
     ]
-    edges = [edge("start", "agent"), edge("agent", "end")]
+    edges = [edge("start", "transcribe"), edge("transcribe", "agent"), edge("agent", "end")]
     return nodes, edges
 
 

--- a/assemblix-app-api/tests/unit/api/test_build_input_data_input_type.py
+++ b/assemblix-app-api/tests/unit/api/test_build_input_data_input_type.py
@@ -1,0 +1,13 @@
+"""Test that _build_input_data sets input_type='text' for non-audio runs."""
+
+from assemblix_api.api.rest.executions import _build_input_data, _parse_execute_payload
+
+
+def test_text_run_sets_input_type_text() -> None:
+    """Verify that text runs get input_type='text' for CEL conditions."""
+    # Arrange
+    request = _parse_execute_payload('{"input": {"message": "hi"}}')
+    # Act
+    input_data = _build_input_data(request, is_debug=False)
+    # Assert
+    assert input_data["input_type"] == "text"

--- a/assemblix-app-api/tests/unit/execution/test_audio_queued_guard.py
+++ b/assemblix-app-api/tests/unit/execution/test_audio_queued_guard.py
@@ -4,9 +4,20 @@ from assemblix_api.execution.voice_gate import ensure_audio_run_is_synchronous
 
 
 def test_audio_run_rejected_when_queued() -> None:
+    # Arrange
+    input_data = {"input_type": "audio"}
+
+    # Act / Assert — raising is the observable outcome, so Act and Assert
+    # are the same `pytest.raises` block.
     with pytest.raises(ValueError, match="synchronous"):
-        ensure_audio_run_is_synchronous(input_data={"input_type": "audio"}, queued=True)
+        ensure_audio_run_is_synchronous(input_data=input_data, queued=True)
 
 
 def test_text_run_allowed_when_queued() -> None:
-    ensure_audio_run_is_synchronous(input_data={"input_type": "text"}, queued=True)  # no raise
+    # Arrange
+    input_data = {"input_type": "text"}
+
+    # Act
+    ensure_audio_run_is_synchronous(input_data=input_data, queued=True)
+
+    # Assert — no exception was raised.

--- a/assemblix-app-api/tests/unit/execution/test_audio_queued_guard.py
+++ b/assemblix-app-api/tests/unit/execution/test_audio_queued_guard.py
@@ -1,0 +1,12 @@
+import pytest
+
+from assemblix_api.execution.voice_gate import ensure_audio_run_is_synchronous
+
+
+def test_audio_run_rejected_when_queued() -> None:
+    with pytest.raises(ValueError, match="synchronous"):
+        ensure_audio_run_is_synchronous(input_data={"input_type": "audio"}, queued=True)
+
+
+def test_text_run_allowed_when_queued() -> None:
+    ensure_audio_run_is_synchronous(input_data={"input_type": "text"}, queued=True)  # no raise

--- a/assemblix-app-api/tests/unit/execution/test_voice_gate_loader.py
+++ b/assemblix-app-api/tests/unit/execution/test_voice_gate_loader.py
@@ -30,9 +30,7 @@ async def test_loader_puts_audio_ref_and_returns_bytes(mocker) -> None:
     workflow = _workflow_with_accept_voice()
 
     # Act
-    audio = await load_audio_into_input_data(
-        workflow=workflow, input_data=input_data, file=file
-    )
+    audio = await load_audio_into_input_data(workflow=workflow, input_data=input_data, file=file)
 
     # Assert
     assert isinstance(audio, AudioInput)

--- a/assemblix-app-api/tests/unit/execution/test_voice_gate_loader.py
+++ b/assemblix-app-api/tests/unit/execution/test_voice_gate_loader.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+from assemblix_api.execution.voice_gate import load_audio_into_input_data
+from assemblix_api.schemas.execution import AudioInput
+
+
+class _UploadStub:
+    def __init__(self, data: bytes, filename: str) -> None:
+        self._data = data
+        self.filename = filename
+
+    async def read(self, n: int) -> bytes:
+        return self._data
+
+
+def _workflow_with_accept_voice() -> SimpleNamespace:
+    start = {
+        "id": "s1",
+        "type": "start",
+        "config": {"acceptVoice": True},
+    }
+    return SimpleNamespace(nodes=[start], project_id=uuid4())
+
+
+async def test_loader_puts_audio_ref_and_returns_bytes(mocker) -> None:
+    # Arrange
+    input_data: dict = {}
+    file = _UploadStub(b"RIFFwav", "voice.wav")
+    workflow = _workflow_with_accept_voice()
+
+    # Act
+    audio = await load_audio_into_input_data(
+        workflow=workflow, input_data=input_data, file=file
+    )
+
+    # Assert
+    assert isinstance(audio, AudioInput)
+    assert audio.bytes == b"RIFFwav"
+    assert input_data["message"] == ""
+    assert input_data["input_type"] == "audio"

--- a/assemblix-app-api/tests/unit/external/test_model_catalog_audio.py
+++ b/assemblix-app-api/tests/unit/external/test_model_catalog_audio.py
@@ -1,0 +1,17 @@
+from assemblix_api.external.llm.model_catalog import find_model_metadata
+
+
+def test_gemini_flash_accepts_audio() -> None:
+    # Arrange / Act
+    meta = find_model_metadata("gemini", "gemini-3-flash-preview")
+    # Assert
+    assert meta is not None
+    assert meta.capabilities.accepts_audio is True
+
+
+def test_deepseek_does_not_accept_audio() -> None:
+    # Arrange / Act
+    meta = find_model_metadata("deepseek", "deepseek-chat")
+    # Assert
+    assert meta is not None
+    assert meta.capabilities.accepts_audio is False

--- a/assemblix-app-api/tests/unit/nodes/_helpers.py
+++ b/assemblix-app-api/tests/unit/nodes/_helpers.py
@@ -25,6 +25,7 @@ def make_context(
     input_data: dict[str, Any] | None = None,
     with_cel: bool = True,
     chat_history: list[dict] | None = None,
+    chat_session_id: Any = None,
     **extra: Any,
 ) -> ExecutionContext:
     """Build a minimal ExecutionContext for node unit tests.
@@ -36,6 +37,7 @@ def make_context(
         with_cel: attach a real ``CELEvaluator`` (needed by condition / set_variable /
             http_request nodes and by ``{{...}}`` template rendering).
         chat_history: in-memory OpenAI-format chat history (used by the agent node).
+        chat_session_id: session id for nodes that persist chat messages (e.g. transcribe).
         **extra: any additional ExecutionContext fields (e.g. credential_service,
             credential_resolver, organization_plan) for nodes that need them.
 
@@ -57,7 +59,7 @@ def make_context(
         workflow=workflow,
         state=state if state is not None else {},
         project_state=project_state if project_state is not None else {},
-        chat_session_id=None,
+        chat_session_id=chat_session_id,
         client_session_id=None,
         input_data=input_data if input_data is not None else {},
         step_number=0,

--- a/assemblix-app-api/tests/unit/nodes/test_agent_node_audio.py
+++ b/assemblix-app-api/tests/unit/nodes/test_agent_node_audio.py
@@ -91,3 +91,19 @@ async def test_audio_turn_on_non_audio_model_raises(mocker) -> None:
     # Act / Assert
     with pytest.raises(ValueError, match="does not accept audio"):
         await node.execute(node_input({"input_type": "audio"}, context))
+
+
+async def test_audio_turn_with_unsupported_mime_raises(mocker) -> None:
+    # Arrange: an audio-capable model, but a mime pydantic_ai's BinaryContent
+    # does not recognize (e.g. a browser MediaRecorder default).
+    audio = AudioInput(bytes=b"\x1aE\xdf\xa3", mime="audio/webm", filename="voice.webm")
+    context = make_context(
+        input_data={"input_type": "audio"},
+        audio_input=audio,
+        chat_history=[{"role": "user", "content": ""}],
+        **_fake_creds(mocker),
+    )
+    node = _agent("gemini-3-flash-preview")
+    # Act / Assert
+    with pytest.raises(ValueError, match="not supported"):
+        await node.execute(node_input({"input_type": "audio"}, context))

--- a/assemblix-app-api/tests/unit/nodes/test_agent_node_audio.py
+++ b/assemblix-app-api/tests/unit/nodes/test_agent_node_audio.py
@@ -1,0 +1,93 @@
+"""Unit tests for audio turns on the AGENT node.
+
+Covers the two branches of Task 6: an audio turn on an audio-capable model
+(``accepts_audio=True``) sends the raw audio as an LLM content part instead of
+transcribing it first, and an audio turn on a non-audio model raises a clear
+``ValueError`` instead of silently dropping the audio.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import pytest
+
+from assemblix_api.enums import PlanTier
+from assemblix_api.nodes.agent_node import AgentNode
+from assemblix_api.schemas.execution import AudioInput
+
+from ._helpers import build_node, make_context, node_input
+
+
+class _FakeResolver:
+    """Stand-in for CredentialResolver: returns a fixed (api_key, is_system_key)."""
+
+    async def resolve(self, **_kwargs: object) -> tuple[str, bool]:
+        return "sk-test", True
+
+
+def _fake_creds(_mocker: Any) -> dict[str, Any]:
+    """Credential wiring kwargs mirroring test_agent_node.py's fake-resolver pattern."""
+    return {
+        "credential_service": types.SimpleNamespace(),  # non-None; resolver bypasses it
+        "credential_resolver": _FakeResolver(),
+        "organization_plan": PlanTier.PRO,
+    }
+
+
+def _content_parts(messages: list[dict]) -> list[dict]:
+    """Flatten any list-typed ``content`` across messages into a flat list of parts."""
+    parts: list[dict] = []
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, list):
+            parts.extend(p for p in content if isinstance(p, dict))
+    return parts
+
+
+def _agent(model: str, provider: str = "gemini") -> AgentNode:
+    return build_node(
+        AgentNode,
+        "agent",
+        {
+            "provider": provider,
+            "model": model,
+            "instructions": [{"role": "user", "content": "answer the user"}],
+            "responseFormat": "text",
+        },
+    )
+
+
+async def test_audio_turn_sends_audio_part_to_gemini(mock_llm, mocker) -> None:
+    # Arrange
+    mock_llm.set_response("hi there")
+    audio = AudioInput(bytes=b"RIFFwav", mime="audio/wav", filename="voice.wav")
+    context = make_context(
+        input_data={"input_type": "audio"},
+        audio_input=audio,
+        chat_history=[{"role": "user", "content": ""}],
+        **_fake_creds(mocker),
+    )
+    node = _agent("gemini-3-flash-preview")
+    # Act
+    await node.execute(node_input({"input_type": "audio"}, context))
+    # Assert
+    messages = mock_llm.calls[0]["messages"]
+    parts = _content_parts(messages)
+    assert any(p.get("type") in {"input_audio", "audio", "file"} for p in parts)
+
+
+async def test_audio_turn_on_non_audio_model_raises(mocker) -> None:
+    # Arrange
+    audio = AudioInput(bytes=b"RIFF", mime="audio/wav", filename="voice.wav")
+    context = make_context(
+        input_data={"input_type": "audio"},
+        audio_input=audio,
+        chat_history=[{"role": "user", "content": ""}],
+        **_fake_creds(mocker),
+    )
+    node = _agent("deepseek-chat", provider="deepseek")
+    # Act / Assert
+    with pytest.raises(ValueError, match="does not accept audio"):
+        await node.execute(node_input({"input_type": "audio"}, context))

--- a/assemblix-app-api/tests/unit/nodes/test_execution_context_audio.py
+++ b/assemblix-app-api/tests/unit/nodes/test_execution_context_audio.py
@@ -1,0 +1,18 @@
+from assemblix_api.schemas.execution import AudioInput
+from ._helpers import make_context
+
+
+def test_context_carries_audio_input() -> None:
+    # Arrange
+    audio = AudioInput(bytes=b"RIFFxxxx", mime="audio/wav", filename="voice.wav")
+    # Act
+    context = make_context(audio_input=audio)
+    # Assert
+    assert context.audio_input is audio
+
+
+def test_context_audio_input_defaults_none() -> None:
+    # Arrange / Act
+    context = make_context()
+    # Assert
+    assert context.audio_input is None

--- a/assemblix-app-api/tests/unit/nodes/test_execution_context_audio.py
+++ b/assemblix-app-api/tests/unit/nodes/test_execution_context_audio.py
@@ -1,4 +1,5 @@
 from assemblix_api.schemas.execution import AudioInput
+
 from ._helpers import make_context
 
 

--- a/assemblix-app-api/tests/unit/nodes/test_transcribe_node.py
+++ b/assemblix-app-api/tests/unit/nodes/test_transcribe_node.py
@@ -14,8 +14,12 @@ async def test_audio_input_is_transcribed(mocker) -> None:
         "assemblix_api.nodes.transcribe_node.transcribe",
         return_value=mocker.Mock(text="hello world"),
     )
+    cred = mocker.Mock()
+    cred.get_voice_api_key_with_fallback = mocker.AsyncMock(return_value=("k", False))
     audio = AudioInput(bytes=b"RIFF", mime="audio/wav", filename="voice.wav")
-    context = make_context(input_data={"input_type": "audio"}, audio_input=audio)
+    context = make_context(
+        input_data={"input_type": "audio"}, audio_input=audio, credential_service=cred
+    )
     node = _node({"voiceModel": {"provider": "openai", "model": "whisper-1"}})
     # Act
     out = await node.execute(node_input({"input_type": "audio"}, context))
@@ -28,7 +32,7 @@ async def test_text_input_passthrough(mocker) -> None:
     # Arrange
     spy = mocker.patch("assemblix_api.nodes.transcribe_node.transcribe")
     context = make_context(input_data={"input_type": "text"})
-    node = _node()
+    node = _node({"voiceModel": {"provider": "openai", "model": "whisper-1"}})
     # Act
     out = await node.execute(node_input({"message": "typed", "input_type": "text"}, context))
     # Assert

--- a/assemblix-app-api/tests/unit/nodes/test_transcribe_node.py
+++ b/assemblix-app-api/tests/unit/nodes/test_transcribe_node.py
@@ -1,3 +1,4 @@
+from assemblix_api.enums import PlanTier
 from assemblix_api.nodes.transcribe_node import TranscribeNode
 from assemblix_api.schemas.execution import AudioInput
 
@@ -18,7 +19,10 @@ async def test_audio_input_is_transcribed(mocker) -> None:
     cred.get_voice_api_key_with_fallback = mocker.AsyncMock(return_value=("k", False))
     audio = AudioInput(bytes=b"RIFF", mime="audio/wav", filename="voice.wav")
     context = make_context(
-        input_data={"input_type": "audio"}, audio_input=audio, credential_service=cred
+        input_data={"input_type": "audio"},
+        audio_input=audio,
+        credential_service=cred,
+        organization_plan=PlanTier.PRO,
     )
     node = _node({"voiceModel": {"provider": "openai", "model": "whisper-1"}})
     # Act
@@ -58,6 +62,7 @@ async def test_save_as_user_message_writes_user_turn(mocker) -> None:
         chat_session_id=uuid4(),
         credential_service=cred,
         chat_message_service=mocker.Mock(save_message=save),
+        organization_plan=PlanTier.PRO,
     )
     node = _node(
         {

--- a/assemblix-app-api/tests/unit/nodes/test_transcribe_node.py
+++ b/assemblix-app-api/tests/unit/nodes/test_transcribe_node.py
@@ -1,0 +1,67 @@
+from assemblix_api.nodes.transcribe_node import TranscribeNode
+from assemblix_api.schemas.execution import AudioInput
+
+from ._helpers import build_node, make_context, node_input
+
+
+def _node(config: dict | None = None) -> TranscribeNode:
+    return build_node(TranscribeNode, "transcribe", config or {})
+
+
+async def test_audio_input_is_transcribed(mocker) -> None:
+    # Arrange
+    mocker.patch(
+        "assemblix_api.nodes.transcribe_node.transcribe",
+        return_value=mocker.Mock(text="hello world"),
+    )
+    audio = AudioInput(bytes=b"RIFF", mime="audio/wav", filename="voice.wav")
+    context = make_context(input_data={"input_type": "audio"}, audio_input=audio)
+    node = _node({"voiceModel": {"provider": "openai", "model": "whisper-1"}})
+    # Act
+    out = await node.execute(node_input({"input_type": "audio"}, context))
+    # Assert
+    assert out.data["message"] == "hello world"
+    assert out.data["input_type"] == "text"
+
+
+async def test_text_input_passthrough(mocker) -> None:
+    # Arrange
+    spy = mocker.patch("assemblix_api.nodes.transcribe_node.transcribe")
+    context = make_context(input_data={"input_type": "text"})
+    node = _node()
+    # Act
+    out = await node.execute(node_input({"message": "typed", "input_type": "text"}, context))
+    # Assert
+    assert out.data["message"] == "typed"
+    spy.assert_not_called()
+
+
+async def test_save_as_user_message_writes_user_turn(mocker) -> None:
+    # Arrange
+    mocker.patch(
+        "assemblix_api.nodes.transcribe_node.transcribe",
+        return_value=mocker.Mock(text="hello"),
+    )
+    save = mocker.AsyncMock()
+    cred = mocker.Mock()
+    cred.get_voice_api_key_with_fallback = mocker.AsyncMock(return_value=("k", False))
+    audio = AudioInput(bytes=b"RIFF", mime="audio/wav", filename="voice.wav")
+    from uuid import uuid4
+
+    context = make_context(
+        input_data={"input_type": "audio"},
+        audio_input=audio,
+        chat_session_id=uuid4(),
+        credential_service=cred,
+        chat_message_service=mocker.Mock(save_message=save),
+    )
+    node = _node(
+        {
+            "voiceModel": {"provider": "openai", "model": "whisper-1"},
+            "saveAsUserMessage": True,
+        }
+    )
+    # Act
+    await node.execute(node_input({"input_type": "audio"}, context))
+    # Assert
+    save.assert_awaited_once()

--- a/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/node-forms/generic/custom-widgets.ts
+++ b/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/node-forms/generic/custom-widgets.ts
@@ -11,6 +11,7 @@
  *   end         — collapsible advanced section with CEL, multi-select, agent-node selector.
  *   set_variable — dynamic update-variable list with type-aware value pickers.
  *   http_request — raw headers/body/query-params editing, credential selection.
+ *   transcribe  — required voiceModel provider/model/credential picker.
  *
  * start / sticker / condition are kept as custom widgets because:
  *   - start: also manages workflow-level state variables (not part of node config).
@@ -26,6 +27,7 @@ import { HTTPRequestNodeForm } from "../http-request-node-form";
 import { StartNodeForm } from "../start-node-form";
 import { StickerNodeForm } from "../sticker-node-form";
 import { ConditionNodeForm } from "../condition-node-form";
+import { TranscribeNodeForm } from "../transcribe-node-form";
 
 // Shared props subset that every custom widget must accept.
 // The dispatcher passes these from nodeEditor.tsx.
@@ -47,4 +49,5 @@ export const customWidgets: Record<string, ComponentType<any>> = {
   start: StartNodeForm,
   sticker: StickerNodeForm,
   condition: ConditionNodeForm,
+  transcribe: TranscribeNodeForm,
 };

--- a/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/node-forms/index.ts
+++ b/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/node-forms/index.ts
@@ -5,6 +5,7 @@ export { ConditionNodeForm } from "./condition-node-form";
 export { SetVariableNodeForm } from "./set-variable-node-form";
 export { EndNodeForm } from "./end-node-form";
 export { HTTPRequestNodeForm } from "./http-request-node-form";
+export { TranscribeNodeForm } from "./transcribe-node-form";
 export { useNodeDataChange } from "./useNodeDataChange";
 export { GenericNodeForm } from "./generic/generic-node-form";
 export { customWidgets } from "./generic/custom-widgets";

--- a/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/node-forms/start-node-form.tsx
+++ b/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/node-forms/start-node-form.tsx
@@ -12,24 +12,7 @@ import { AddVariablePopover } from "@/shared/ui";
 import { Button } from "@/shared/ui/button";
 import { Label } from "@/shared/ui/label";
 import { Switch } from "@/shared/ui/switch";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/shared/ui/select";
 import { Textarea } from "@/shared/ui/textarea";
-import {
-  useGetVoiceProvidersQuery,
-  useGetVoiceProviderModelsQuery,
-} from "@/entities/voice-model";
-import {
-  CredentialSelect,
-  getCredentialTypeForProvider,
-} from "@/entities/credential";
-import { useGetBillingUsageQuery } from "@/entities/billing";
-import { useGetServerConfigQuery } from "@/entities/config";
 import { useUpdateWorkflowMutation } from "@/entities/workflow/api/workflow.api";
 import { toast } from "sonner";
 import { StateVariables } from "../state/stateVariables";
@@ -62,58 +45,15 @@ export const StartNodeForm = ({
   const [formData, setFormData] = useState<StartNodeConfig>({
     firstPhrase: config?.firstPhrase ?? "",
     acceptVoice: config?.acceptVoice ?? false,
-    voiceModel: config?.voiceModel,
   });
 
   useEffect(() => {
     handleDataChange(formData);
   }, [formData, handleDataChange]);
 
-  // Voice input: transcription provider/model picker (same UX as the agent node).
-  const { data: voiceProviders = [] } = useGetVoiceProvidersQuery();
-  const voiceProvider = formData.voiceModel?.provider;
-  const { data: voiceModels = [], isLoading: isLoadingVoiceModels } =
-    useGetVoiceProviderModelsQuery(
-      { providerName: voiceProvider ?? "" },
-      { skip: !voiceProvider }
-    );
-
   const handleAcceptVoiceChange = (checked: boolean) =>
-    setFormData((prev) => ({
-      ...prev,
-      acceptVoice: checked,
-      voiceModel:
-        checked && !prev.voiceModel
-          ? { provider: "openai", model: "whisper-1" }
-          : prev.voiceModel,
-    }));
+    setFormData((prev) => ({ ...prev, acceptVoice: checked }));
 
-  const handleVoiceProviderChange = (value: string) =>
-    setFormData((prev) => ({
-      ...prev,
-      // Reset model + credential when the provider changes (same as the agent node).
-      voiceModel: { provider: value, model: "", credentialId: "" },
-    }));
-
-  const handleVoiceModelChange = (value: string) =>
-    setFormData((prev) => ({
-      ...prev,
-      voiceModel: {
-        provider: prev.voiceModel?.provider ?? "openai",
-        model: value,
-        credentialId: prev.voiceModel?.credentialId,
-      },
-    }));
-
-  const handleVoiceCredentialChange = (credentialId: string) =>
-    setFormData((prev) => ({
-      ...prev,
-      voiceModel: {
-        provider: prev.voiceModel?.provider ?? "openai",
-        model: prev.voiceModel?.model ?? "",
-        credentialId,
-      },
-    }));
   // Получаем переменные из Redux store
   const variablesList = useSelector((state: RootState) =>
     selectVariablesByWorkflowId(state, workflow.id)
@@ -125,21 +65,6 @@ export const StartNodeForm = ({
     skip: !currentProjectId,
   });
   const projectVariables = (project?.stateSchema || []) as StateVariable[];
-
-  // Credential picker for the voice model — same gating logic as the agent node.
-  const { data: billingUsage } = useGetBillingUsageQuery(undefined, {
-    skip: !currentProjectId,
-  });
-  const canUseOwnKeys = billingUsage?.features.canUseOwnKeys ?? false;
-  const { data: serverConfig } = useGetServerConfigQuery();
-  const voiceCredentialType = voiceProvider
-    ? getCredentialTypeForProvider(voiceProvider)
-    : undefined;
-  const hasVoiceSystemKey = voiceProvider
-    ? serverConfig
-      ? Boolean(serverConfig.systemApiKeys[voiceProvider])
-      : true
-    : false;
 
   const handleSaveVariable = async (
     variable: StateVariable,
@@ -242,80 +167,6 @@ export const StartNodeForm = ({
           <p className="text-xs text-muted-foreground">
             {t("nodeForms.start.acceptVoiceHint")}
           </p>
-
-          {formData.acceptVoice && (
-            <div className="space-y-2">
-              <div className="flex justify-between items-center gap-2">
-                <Label htmlFor="start-voice-provider" className="shrink-0">
-                  {t("nodeForms.start.voiceProvider")}
-                </Label>
-                <Select
-                  value={formData.voiceModel?.provider}
-                  onValueChange={handleVoiceProviderChange}
-                >
-                  <SelectTrigger
-                    id="start-voice-provider"
-                    className="border-none shadow-none ring-0! text-xs"
-                  >
-                    <SelectValue
-                      placeholder={t("nodeForms.start.selectVoiceProvider")}
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {voiceProviders.map((p) => (
-                      <SelectItem key={p.name} value={p.name} className="text-xs">
-                        {p.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              {canUseOwnKeys && voiceCredentialType && (
-                <div className="flex flex-col gap-1.5">
-                  <Label htmlFor="start-voice-credential" className="text-xs">
-                    {t("nodeForms.start.voiceCredential")}
-                  </Label>
-                  <CredentialSelect
-                    selectedCredentialId={formData.voiceModel?.credentialId}
-                    onSelect={handleVoiceCredentialChange}
-                    credentialType={voiceCredentialType}
-                    placeholder={t("nodeForms.start.selectVoiceCredential")}
-                    showSystemToken={hasVoiceSystemKey}
-                  />
-                </div>
-              )}
-              <div className="flex justify-between items-center gap-2">
-                <Label htmlFor="start-voice-model" className="shrink-0">
-                  {t("nodeForms.start.voiceModel")}
-                </Label>
-                <Select
-                  value={formData.voiceModel?.model}
-                  onValueChange={handleVoiceModelChange}
-                  disabled={isLoadingVoiceModels || !formData.voiceModel?.provider}
-                >
-                  <SelectTrigger
-                    id="start-voice-model"
-                    className="border-none shadow-none ring-0! text-xs"
-                  >
-                    <SelectValue
-                      placeholder={
-                        isLoadingVoiceModels
-                          ? t("nodeForms.start.loadingVoiceModels")
-                          : t("nodeForms.start.selectVoiceModel")
-                      }
-                    />
-                  </SelectTrigger>
-                  <SelectContent position="popper" sideOffset={5} align="end">
-                    {voiceModels.map((m) => (
-                      <SelectItem key={m.id} value={m.id}>
-                        {m.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-          )}
         </div>
 
         <Divider />

--- a/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/node-forms/transcribe-node-form.tsx
+++ b/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/node-forms/transcribe-node-form.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { BaseForm } from "./base-form";
+import { useNodeDataChange } from "./useNodeDataChange";
+import { Label } from "@/shared/ui/label";
+import { Switch } from "@/shared/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shared/ui/select";
+import {
+  useGetVoiceProvidersQuery,
+  useGetVoiceProviderModelsQuery,
+} from "@/entities/voice-model";
+import {
+  CredentialSelect,
+  getCredentialTypeForProvider,
+} from "@/entities/credential";
+import { useGetBillingUsageQuery } from "@/entities/billing";
+import { useGetServerConfigQuery } from "@/entities/config";
+import { useSelector } from "react-redux";
+import { selectCurrentProjectId } from "@/entities/organization";
+import type { VoiceModelConfig } from "@/entities/workflow/model/types";
+
+type TranscribeNodeConfig = {
+  voiceModel?: VoiceModelConfig;
+  saveAsUserMessage?: boolean;
+};
+
+interface TranscribeNodeFormProps {
+  nodeId: string;
+  config?: TranscribeNodeConfig;
+  projectId?: string;
+}
+
+const defaultConfig: TranscribeNodeConfig = {
+  voiceModel: { provider: "openai", model: "whisper-1" },
+  saveAsUserMessage: true,
+};
+
+/**
+ * Config form for the "transcribe" node: audio -> text.
+ *
+ * voiceModel is required by the backend; the provider/model/credential picker
+ * here mirrors the transcription-scoped picker that used to live on the START
+ * node (transcription moved from START to this dedicated node).
+ */
+export const TranscribeNodeForm = ({
+  nodeId,
+  config,
+  projectId,
+}: TranscribeNodeFormProps) => {
+  const { t } = useTranslation();
+  const handleDataChange = useNodeDataChange(nodeId);
+  const [formData, setFormData] = useState<TranscribeNodeConfig>({
+    voiceModel: config?.voiceModel ?? defaultConfig.voiceModel,
+    saveAsUserMessage: config?.saveAsUserMessage ?? true,
+  });
+
+  useEffect(() => {
+    handleDataChange(formData);
+  }, [formData, handleDataChange]);
+
+  const { data: voiceProviders = [] } = useGetVoiceProvidersQuery();
+  const voiceProvider = formData.voiceModel?.provider;
+  const { data: voiceModels = [], isLoading: isLoadingVoiceModels } =
+    useGetVoiceProviderModelsQuery(
+      { providerName: voiceProvider ?? "" },
+      { skip: !voiceProvider }
+    );
+
+  const handleVoiceProviderChange = (value: string) =>
+    setFormData((prev) => ({
+      ...prev,
+      // Reset model + credential when the provider changes (same as the agent node).
+      voiceModel: { provider: value, model: "", credentialId: "" },
+    }));
+
+  const handleVoiceModelChange = (value: string) =>
+    setFormData((prev) => ({
+      ...prev,
+      voiceModel: {
+        provider: prev.voiceModel?.provider ?? "openai",
+        model: value,
+        credentialId: prev.voiceModel?.credentialId,
+      },
+    }));
+
+  const handleVoiceCredentialChange = (credentialId: string) =>
+    setFormData((prev) => ({
+      ...prev,
+      voiceModel: {
+        provider: prev.voiceModel?.provider ?? "openai",
+        model: prev.voiceModel?.model ?? "",
+        credentialId,
+      },
+    }));
+
+  const handleSaveAsUserMessageChange = (checked: boolean) =>
+    setFormData((prev) => ({ ...prev, saveAsUserMessage: checked }));
+
+  const currentProjectId = useSelector(selectCurrentProjectId);
+  const { data: billingUsage } = useGetBillingUsageQuery(undefined, {
+    skip: !currentProjectId,
+  });
+  const canUseOwnKeys = billingUsage?.features.canUseOwnKeys ?? false;
+  const { data: serverConfig } = useGetServerConfigQuery();
+  const voiceCredentialType = voiceProvider
+    ? getCredentialTypeForProvider(voiceProvider)
+    : undefined;
+  const hasVoiceSystemKey = voiceProvider
+    ? serverConfig
+      ? Boolean(serverConfig.systemApiKeys[voiceProvider])
+      : true
+    : false;
+
+  return (
+    <BaseForm
+      nodeType="transcribe"
+      label={t("nodeForms.transcribe.title")}
+      projectId={projectId}
+    >
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <div className="flex justify-between items-center gap-2">
+            <Label htmlFor="transcribe-voice-provider" className="shrink-0">
+              {t("nodeForms.transcribe.voiceProvider")}
+            </Label>
+            <Select
+              value={formData.voiceModel?.provider}
+              onValueChange={handleVoiceProviderChange}
+            >
+              <SelectTrigger
+                id="transcribe-voice-provider"
+                className="border-none shadow-none ring-0! text-xs"
+              >
+                <SelectValue
+                  placeholder={t("nodeForms.transcribe.selectVoiceProvider")}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {voiceProviders.map((p) => (
+                  <SelectItem key={p.name} value={p.name} className="text-xs">
+                    {p.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {canUseOwnKeys && voiceCredentialType && (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="transcribe-voice-credential" className="text-xs">
+                {t("nodeForms.transcribe.voiceCredential")}
+              </Label>
+              <CredentialSelect
+                selectedCredentialId={formData.voiceModel?.credentialId}
+                onSelect={handleVoiceCredentialChange}
+                credentialType={voiceCredentialType}
+                placeholder={t("nodeForms.transcribe.selectVoiceCredential")}
+                showSystemToken={hasVoiceSystemKey}
+              />
+            </div>
+          )}
+          <div className="flex justify-between items-center gap-2">
+            <Label htmlFor="transcribe-voice-model" className="shrink-0">
+              {t("nodeForms.transcribe.voiceModel")}
+            </Label>
+            <Select
+              value={formData.voiceModel?.model}
+              onValueChange={handleVoiceModelChange}
+              disabled={isLoadingVoiceModels || !formData.voiceModel?.provider}
+            >
+              <SelectTrigger
+                id="transcribe-voice-model"
+                className="border-none shadow-none ring-0! text-xs"
+              >
+                <SelectValue
+                  placeholder={
+                    isLoadingVoiceModels
+                      ? t("nodeForms.transcribe.loadingVoiceModels")
+                      : t("nodeForms.transcribe.selectVoiceModel")
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent position="popper" sideOffset={5} align="end">
+                {voiceModels.map((m) => (
+                  <SelectItem key={m.id} value={m.id}>
+                    {m.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="flex justify-between gap-4 items-center">
+          <Label htmlFor="transcribe-save-as-user-message">
+            {t("nodeForms.transcribe.saveAsUserMessage")}
+          </Label>
+          <Switch
+            id="transcribe-save-as-user-message"
+            checked={formData.saveAsUserMessage ?? true}
+            onCheckedChange={handleSaveAsUserMessageChange}
+            showIcons={false}
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {t("nodeForms.transcribe.saveAsUserMessageHint")}
+        </p>
+      </div>
+    </BaseForm>
+  );
+};

--- a/assemblix-app-web/src/entities/workflow/model/types.ts
+++ b/assemblix-app-web/src/entities/workflow/model/types.ts
@@ -45,10 +45,10 @@ export enum NodeType {
 
 export type StartNodeConfig = {
   firstPhrase?: string;
-  // Voice input: when enabled, the /execute/audio endpoints transcribe an
-  // inbound audio blob into the run's message using `voiceModel`.
+  // Voice input: when enabled, the /execute/audio endpoints accept an inbound
+  // audio blob. Transcription itself is configured on a downstream "transcribe"
+  // node (see TranscribeNodeForm), not here.
   acceptVoice?: boolean;
-  voiceModel?: VoiceModelConfig;
 };
 
 export interface VoiceModelConfig {

--- a/assemblix-app-web/src/shared/i18n/locales/en.json
+++ b/assemblix-app-web/src/shared/i18n/locales/en.json
@@ -594,13 +594,6 @@
       "firstPhrasePlaceholder": "Hi! How can I help you?",
       "acceptVoice": "Accept voice input",
       "acceptVoiceHint": "Allow sending audio; it is transcribed to text before the run.",
-      "voiceProvider": "Voice provider",
-      "voiceModel": "Voice model",
-      "voiceCredential": "Voice credential",
-      "selectVoiceProvider": "Select provider",
-      "selectVoiceModel": "Select model",
-      "selectVoiceCredential": "Select credential",
-      "loadingVoiceModels": "Loading...",
       "inputVariables": "Input Variables",
       "projectVariables": "Project Variables",
       "projectVariablesNote": "These variables are defined at the project level and available in all workflows",
@@ -612,6 +605,18 @@
       "variableAdded": "Variable \"{{name}}\" added",
       "variableDeleteError": "Error deleting variable",
       "variableDeleted": "Variable deleted"
+    },
+    "transcribe": {
+      "title": "Transcribe",
+      "voiceProvider": "Voice provider",
+      "voiceModel": "Voice model",
+      "voiceCredential": "Voice credential",
+      "selectVoiceProvider": "Select provider",
+      "selectVoiceModel": "Select model",
+      "selectVoiceCredential": "Select credential",
+      "loadingVoiceModels": "Loading...",
+      "saveAsUserMessage": "Save as user message",
+      "saveAsUserMessageHint": "Add the transcribed text to the run history as a user message."
     },
     "avatar": {
       "provider": "Avatar provider",

--- a/assemblix-app-web/src/shared/i18n/locales/es.json
+++ b/assemblix-app-web/src/shared/i18n/locales/es.json
@@ -594,13 +594,6 @@
       "firstPhrasePlaceholder": "¡Hola! ¿En qué puedo ayudarte?",
       "acceptVoice": "Aceptar entrada de voz",
       "acceptVoiceHint": "Permitir enviar audio; se transcribe a texto antes de la ejecución.",
-      "voiceProvider": "Proveedor de voz",
-      "voiceModel": "Modelo de voz",
-      "voiceCredential": "Credencial de voz",
-      "selectVoiceProvider": "Seleccionar proveedor",
-      "selectVoiceModel": "Seleccionar modelo",
-      "selectVoiceCredential": "Seleccionar credencial",
-      "loadingVoiceModels": "Cargando...",
       "inputVariables": "Variables de entrada",
       "projectVariables": "Variables del proyecto",
       "projectVariablesNote": "Estas variables se definen a nivel de proyecto y están disponibles en todos los flujos de trabajo",
@@ -612,6 +605,18 @@
       "variableAdded": "Variable \"{{name}}\" añadida",
       "variableDeleteError": "Error al eliminar la variable",
       "variableDeleted": "Variable eliminada"
+    },
+    "transcribe": {
+      "title": "Transcribir",
+      "voiceProvider": "Proveedor de voz",
+      "voiceModel": "Modelo de voz",
+      "voiceCredential": "Credencial de voz",
+      "selectVoiceProvider": "Seleccionar proveedor",
+      "selectVoiceModel": "Seleccionar modelo",
+      "selectVoiceCredential": "Seleccionar credencial",
+      "loadingVoiceModels": "Cargando...",
+      "saveAsUserMessage": "Guardar como mensaje del usuario",
+      "saveAsUserMessageHint": "Añadir el texto transcrito al historial de la ejecución como mensaje del usuario."
     },
     "avatar": {
       "provider": "Proveedor de avatar",

--- a/assemblix-app-web/src/shared/i18n/locales/ru.json
+++ b/assemblix-app-web/src/shared/i18n/locales/ru.json
@@ -596,13 +596,6 @@
       "firstPhrasePlaceholder": "Привет! Чем могу помочь?",
       "acceptVoice": "Принимать голосом",
       "acceptVoiceHint": "Разрешить отправку аудио; оно расшифровывается в текст перед запуском.",
-      "voiceProvider": "Провайдер распознавания",
-      "voiceModel": "Модель распознавания",
-      "voiceCredential": "Токен распознавания",
-      "selectVoiceProvider": "Выберите провайдера",
-      "selectVoiceModel": "Выберите модель",
-      "selectVoiceCredential": "Выберите токен",
-      "loadingVoiceModels": "Загрузка...",
       "inputVariables": "Входные переменные",
       "projectVariables": "Переменные проекта",
       "projectVariablesNote": "Эти переменные определены на уровне проекта и доступны во всех воркфлоу",
@@ -614,6 +607,18 @@
       "variableAdded": "Переменная \"{{name}}\" добавлена",
       "variableDeleteError": "Ошибка удаления переменной",
       "variableDeleted": "Переменная удалена"
+    },
+    "transcribe": {
+      "title": "Распознавание речи",
+      "voiceProvider": "Провайдер распознавания",
+      "voiceModel": "Модель распознавания",
+      "voiceCredential": "Токен распознавания",
+      "selectVoiceProvider": "Выберите провайдера",
+      "selectVoiceModel": "Выберите модель",
+      "selectVoiceCredential": "Выберите токен",
+      "loadingVoiceModels": "Загрузка...",
+      "saveAsUserMessage": "Сохранять как сообщение пользователя",
+      "saveAsUserMessageHint": "Добавить расшифрованный текст в историю запуска как сообщение пользователя."
     },
     "avatar": {
       "provider": "Провайдер аватара",


### PR DESCRIPTION
Делает аудио нативным входом для мультимодальных (Gemini) агентов и превращает транскрибцию из скрытого шага в гейте в **явную ноду графа**. 14 коммитов, реализовано по TDD с ревью каждой задачи; отдельный whole-branch review на финале.

## Что нового (примитивы)

- **Слот сообщения носит аудио.** `/execute/audio` больше не транскрибирует в гейте — кладёт аудио на runtime-поле `ExecutionContext.audio_input` (никогда не сериализуется) и ставит `input.input_type="audio"` (доступно в CEL для ветвления).
- **Нода `transcribe`** (`@register_node("transcribe")`, конфиг `{voiceModel, saveAsUserMessage}`) нормализует аудио→текст там, где её поставили; `saveAsUserMessage` пишет реплику пользователя в историю. Оборачивает существующий STT (`external/voice/transcription.py`).
- **Агент принимает аудио напрямую.** На аудио-ходу с моделью, помеченной `accepts_audio` (Gemini), текущая реплика уходит как `BinaryContent`-часть через pydantic-ai + litellm (шим не менялся). Не-аудио модель → понятная рантайм-ошибка «поставь ноду транскрибции». Неподдерживаемый mime → actionable-ошибка (валидация против набора из pydantic_ai).
- **Фронт:** нода `transcribe` появляется в палитре (descriptor-driven, как `delay`) и настраивается кастом-формой (пикер модели транскрипции + тумблер). Мёртвый voice-model-пикер убран со START (там остаётся только `acceptVoice`).

## ⚠️ Изменение поведения

Раньше `/execute/audio` авто-транскрибировал аудио в `input.message` для любого `acceptVoice`-воркфлоу. Теперь транскрибция — **явная нода**. Воркфлоу без ноды транскрибции: агент на не-аудио модели → падает с понятной ошибкой; агент на Gemini → получает аудио напрямую (и без ноды user-turn в историю не пишется — осознанный трейд-офф). Боевых voice-воркфлоу на момент мержа нет, поэтому миграция не требуется.

## Известное ограничение (follow-up, не в этом PR)

Latency-композиция «аудио → агент ∥ transcribe → история» требует параллельного fork'а. Параллельный движок (`_execution_loop_parallel`) имеет **пред-существующий** баг: конкурентные DB-записи двух веток на общей `AsyncSession` → `InvalidRequestError`. Не введён этой веткой, но фича на него опирается. Нужен отдельный тикет (сессия на ветку / сериализация записей). Интеграционные тесты пока покрывают линейные графы.

## Проверки

- Backend: `make check` зелёный — ruff/format/mypy/bandit + **289 тестов, покрытие 70%**. Юнит-тесты на loader, queued-guard, каталог, agent audio/non-audio, transcribe passthrough/save, mime-валидацию + честный e2e HTTP-тест.
- Frontend: `yarn build` (tsc + vite) + eslint зелёные.
- ⚠️ Ручной прогон записи в браузере (drag ноды transcribe в ОТП-подобный граф) стоит прокликать перед мержем — в окружении не гонялся.

Спек и план — в `internal-docs/superpowers/` (не в git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)