### PR TITLE
fix(web): give the transcribe node a color + audio icon

### DIFF
--- a/assemblix-app-api/assemblix_api/nodes/transcribe_node.py
+++ b/assemblix-app-api/assemblix_api/nodes/transcribe_node.py
@@ -64,6 +64,7 @@ class TranscribeNode(BaseNode):
             display_name="Transcribe",
             description="Turn an audio turn into text (passthrough if already text).",
             icon="AudioLines",
+            color="node-data",
             properties=[
                 NodeProperty(
                     name="saveAsUserMessage",

--- a/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/nodes/icon-by-name.ts
+++ b/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/nodes/icon-by-name.ts
@@ -20,6 +20,8 @@ import {
   RefreshCw,
   AlertCircle,
   CheckCircle2,
+  AudioLines,
+  Mic,
   type LucideIcon,
 } from "lucide-react";
 
@@ -49,4 +51,6 @@ export const iconByName: Record<string, LucideIcon> = {
   RefreshCw,
   AlertCircle,
   CheckCircle2,
+  AudioLines,
+  Mic,
 };


### PR DESCRIPTION
Дополняет смёрженный #42. Интерфейсная правка ноды `transcribe` — последний коммит не вошёл в мерж #42 (как ранее с #38→#40).

На канвасе нода `transcribe` рисовалась **бесцветной** по двум причинам:
1. Дескриптор отдавал `color="node-default"` — несуществующий токен → нода без цвета (и fallback `?? "node-llm"` не срабатывал, т.к. значение не пустое).
2. Иконка `AudioLines` не была зарегистрирована в фронтовом `iconByName` → падала в дефолтный `Zap`.

**Фикс:**
- Бэкенд: в `descriptor()` ноды `transcribe` задан `color="node-data"` (валидный токен, как у SET_VARIABLE).
- Фронт: `AudioLines` (+ `Mic` про запас) добавлены в `icon-by-name.ts`.

Теперь нода отображается с цветом `node-data` и иконкой-волной. eslint + `yarn build` зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)