### PR TITLE
fix(execution): serialize shared session for parallel fork branches

### DIFF
--- a/assemblix-app-api/assemblix_api/database/engine.py
+++ b/assemblix-app-api/assemblix_api/database/engine.py
@@ -2,7 +2,10 @@
 Database engine and session management
 """
 
-from collections.abc import AsyncGenerator, Generator
+import asyncio
+from collections.abc import AsyncGenerator, AsyncIterator, Generator
+from contextlib import asynccontextmanager
+from typing import Any
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
@@ -11,6 +14,107 @@ from sqlalchemy.orm import Session
 from assemblix_api.core.settings import get_settings
 
 settings = get_settings()
+
+
+class SerializedAsyncSession(AsyncSession):
+    """AsyncSession that serializes DB operations across concurrent asyncio tasks.
+
+    A workflow run shares one session across every branch. On the parallel engine,
+    fork branches run as concurrent tasks, so two branches may `await` the DB at the
+    same instant — which a stock AsyncSession forbids ("This session is provisioning a
+    new connection; concurrent operations are not permitted").
+
+    A per-task *reentrant* lock guards the coroutine methods that actually touch the
+    connection. Reentrancy is required because some methods call others through the
+    async facade (`scalar`/`scalars` → `execute`, `stream_scalars` → `stream`); a plain
+    lock would deadlock within a single task. Cross-task calls serialize on the DB touch
+    only — the expensive awaits between DB calls (LLM/HTTP) still overlap, and the single
+    transaction / node-boundary checkpoint semantics are unchanged.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._db_lock = asyncio.Lock()
+        self._db_lock_owner: asyncio.Task | None = None
+        self._db_lock_depth = 0
+
+    @asynccontextmanager
+    async def _serialized(self) -> AsyncIterator[None]:
+        task = asyncio.current_task()
+        if self._db_lock_owner is task and task is not None:
+            # Nested DB call within the branch that already holds the lock.
+            self._db_lock_depth += 1
+            try:
+                yield
+            finally:
+                self._db_lock_depth -= 1
+            return
+        await self._db_lock.acquire()
+        self._db_lock_owner = task
+        self._db_lock_depth = 1
+        try:
+            yield
+        finally:
+            self._db_lock_depth -= 1
+            if self._db_lock_depth == 0:
+                self._db_lock_owner = None
+                self._db_lock.release()
+
+    async def execute(self, *args: Any, **kwargs: Any) -> Any:
+        async with self._serialized():
+            return await super().execute(*args, **kwargs)
+
+    async def scalar(self, *args: Any, **kwargs: Any) -> Any:
+        async with self._serialized():
+            return await super().scalar(*args, **kwargs)
+
+    async def scalars(self, *args: Any, **kwargs: Any) -> Any:
+        async with self._serialized():
+            return await super().scalars(*args, **kwargs)
+
+    async def stream(self, *args: Any, **kwargs: Any) -> Any:
+        async with self._serialized():
+            return await super().stream(*args, **kwargs)
+
+    async def stream_scalars(self, *args: Any, **kwargs: Any) -> Any:
+        async with self._serialized():
+            return await super().stream_scalars(*args, **kwargs)
+
+    async def get(self, *args: Any, **kwargs: Any) -> Any:
+        async with self._serialized():
+            return await super().get(*args, **kwargs)
+
+    async def get_one(self, *args: Any, **kwargs: Any) -> Any:
+        async with self._serialized():
+            return await super().get_one(*args, **kwargs)
+
+    async def refresh(self, *args: Any, **kwargs: Any) -> None:
+        async with self._serialized():
+            await super().refresh(*args, **kwargs)
+
+    async def merge(self, *args: Any, **kwargs: Any) -> Any:
+        async with self._serialized():
+            return await super().merge(*args, **kwargs)
+
+    async def delete(self, *args: Any, **kwargs: Any) -> None:
+        async with self._serialized():
+            await super().delete(*args, **kwargs)
+
+    async def flush(self, *args: Any, **kwargs: Any) -> None:
+        async with self._serialized():
+            await super().flush(*args, **kwargs)
+
+    async def commit(self) -> None:
+        async with self._serialized():
+            await super().commit()
+
+    async def rollback(self) -> None:
+        async with self._serialized():
+            await super().rollback()
+
+    async def connection(self, *args: Any, **kwargs: Any) -> Any:
+        async with self._serialized():
+            return await super().connection(*args, **kwargs)
 
 # Sync engine (Alembic migrations and startup health-check).
 engine = create_engine(

--- a/assemblix-app-api/assemblix_api/dependencies.py
+++ b/assemblix-app-api/assemblix_api/dependencies.py
@@ -634,7 +634,10 @@ async def run_workflow_isolated(
         execution_id_future: Future that receives the execution ID after it is created
         result_future: Future that receives the ExecutionResult on completion
     """
-    from assemblix_api.database.engine import get_async_engine
+    from assemblix_api.database.engine import (
+        SerializedAsyncSession,
+        get_async_engine,
+    )
     from assemblix_api.database.repositories.workflow_repository import (
         WorkflowRepository,
     )
@@ -644,7 +647,9 @@ async def run_workflow_isolated(
     # expire_on_commit=False: the executor commits at node boundaries to release the DB
     # connection during LLM/HTTP awaits; the `execution`/`workflow` ORM objects must
     # survive those commits without a lazy async reload (MissingGreenlet).
-    async with AsyncSession(engine, expire_on_commit=False) as session:
+    # SerializedAsyncSession: parallel fork branches share this session and may await the
+    # DB concurrently — the per-task lock prevents SQLAlchemy's concurrent-op error.
+    async with SerializedAsyncSession(engine, expire_on_commit=False) as session:
         try:
             workflow_repo = WorkflowRepository(session)
             # Keep a reference to execution_repo for post-commit notifications.

--- a/assemblix-app-api/assemblix_api/queue/jobs.py
+++ b/assemblix-app-api/assemblix_api/queue/jobs.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from uuid import UUID
 
 import structlog
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from assemblix_api.database.engine import get_async_engine
+from assemblix_api.database.engine import SerializedAsyncSession, get_async_engine
 
 # Module-level imports so tests can patch them as assemblix_api.queue.jobs.*
 from assemblix_api.database.repositories.workflow_repository import WorkflowRepository
@@ -65,7 +64,9 @@ async def run_workflow_job(
     # expire_on_commit=False: the executor commits at node boundaries (to release the
     # DB connection during LLM/HTTP awaits), and the long-lived `execution` ORM object
     # must stay usable across those commits without a lazy reload (MissingGreenlet).
-    async with AsyncSession(engine, expire_on_commit=False) as session:
+    # SerializedAsyncSession: parallel fork branches share this session and may await the
+    # DB concurrently — the per-task lock prevents SQLAlchemy's concurrent-op error.
+    async with SerializedAsyncSession(engine, expire_on_commit=False) as session:
         try:
             workflow_repo = WorkflowRepository(session)
             workflow = await workflow_repo.get_by_id(wf_uuid)

--- a/assemblix-app-api/tests/integration/test_serialized_session.py
+++ b/assemblix-app-api/tests/integration/test_serialized_session.py
@@ -1,0 +1,76 @@
+"""Regression: parallel fork branches share one AsyncSession.
+
+A workflow run uses a single AsyncSession for every branch (see build_executor).
+On the parallel engine, fork branches execute as concurrent asyncio tasks, so two
+branches can `await` the DB at the same instant. A bare AsyncSession forbids that
+("concurrent operations are not permitted"). SerializedAsyncSession serializes only
+the DB touch points with a per-task reentrant lock, so concurrent branches succeed
+while the expensive awaits (LLM/HTTP) between DB calls still overlap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assemblix_api.database.engine import SerializedAsyncSession
+
+
+async def _overlapping_queries(session: AsyncSession, n: int = 6) -> list[int]:
+    """Fire n queries concurrently; pg_sleep widens each await window so they overlap."""
+
+    async def one(i: int) -> int:
+        result = await session.execute(
+            text("SELECT CAST(:i AS INTEGER) AS i, pg_sleep(0.05)"), {"i": i}
+        )
+        return int(result.scalar())
+
+    return await asyncio.gather(*(one(i) for i in range(n)))
+
+
+async def test_plain_session_races_on_concurrent_ops(committed_db) -> None:
+    """Control: a bare AsyncSession raises when two branches await the DB at once."""
+    # Arrange
+    session = AsyncSession(committed_db)
+
+    # Act / Assert — the shared-session hazard reproduces on the stock session. The guard
+    # surfaces as one of SQLAlchemy's concurrency errors ("concurrent operations are not
+    # permitted" in prod; an IllegalStateChangeState mid-provision here) — match the family.
+    with pytest.raises(Exception, match="concurrent operations|already in progress|can't be called here"):
+        await _overlapping_queries(session)
+
+    # The race leaves the bare session mid-provision; closing it is best-effort teardown.
+    with contextlib.suppress(Exception):
+        await session.close()
+
+
+async def test_serialized_session_allows_concurrent_branches(committed_db) -> None:
+    """SerializedAsyncSession serializes DB touches so concurrent branches all succeed."""
+    # Arrange
+    session = SerializedAsyncSession(committed_db)
+
+    # Act
+    results = await _overlapping_queries(session)
+
+    # Assert — every branch completed, none lost to the concurrency guard.
+    assert sorted(results) == [0, 1, 2, 3, 4, 5]
+
+    await session.close()
+
+
+async def test_serialized_session_reentrant_scalar(committed_db) -> None:
+    """`scalar` calls `execute` internally; the per-task lock must reenter, not deadlock."""
+    # Arrange
+    session = SerializedAsyncSession(committed_db)
+
+    # Act — would hang forever if the lock were non-reentrant within one task.
+    value = await asyncio.wait_for(session.scalar(text("SELECT 42")), timeout=5)
+
+    # Assert
+    assert value == 42
+
+    await session.close()


### PR DESCRIPTION
## Проблема

Один прогон воркфлоу делит одну `AsyncSession` на все ветки (см. `build_executor`). На параллельном движке (`_execution_loop_parallel`) форк-ветки выполняются как конкурентные `asyncio.create_task`, поэтому две ветки могут в один момент делать `await` к БД. Голая `AsyncSession` это запрещает:

> This session is provisioning a new connection; concurrent operations are not permitted

Всплывает на любом AND-split, где обе ветки пишут в БД — например transcribe-нода с `saveAsUserMessage` пишет user-turn параллельно коммиту агента на границе ноды.

## Фикс

`SerializedAsyncSession` — подкласс `AsyncSession`, у которого coroutine-методы, реально трогающие соединение (`execute, scalar, scalars, stream, stream_scalars, get, get_one, refresh, merge, delete, flush, commit, rollback, connection`), захватывают **per-task reentrant** async-лок.

- Конкурентные ветки сериализуются **только на момент DB-обращения**; дорогие `await` между DB-вызовами (LLM/HTTP) по-прежнему идут параллельно.
- Единая транзакция и семантика чек-поинтов на границах нод не меняются.
- Реентрантность обязательна: часть методов зовёт другие через async-фасад (`scalar/scalars → execute`, `stream_scalars → stream`) — без неё был бы дедлок внутри одной ветки.

Подставлено ровно в двух точках прогона: `run_workflow_isolated` (debug/фон) и Arq-воркер (`queue/jobs.py`). Request-путь и healthcheck не тронуты — там конкурентного фан-аута нет.

## Тесты

- Новый `tests/integration/test_serialized_session.py`: контроль доказывает, что голая `AsyncSession` падает на перекрывающихся `await` (через `pg_sleep`); обёртка их пропускает; отдельный тест на реентрантность `scalar` (не виснет).
- Существующие `test_workflow_parallel.py`, queue-тесты, voice/streaming e2e — зелёные. ruff + mypy чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)