### PR TITLE
feat: gpt-audio support + base64 audio input for voice nodes

### DIFF
--- a/assemblix-app-api/assemblix_api/api/rest/executions.py
+++ b/assemblix-app-api/assemblix_api/api/rest/executions.py
@@ -67,6 +67,7 @@ from assemblix_api.enums import ExecutionStatus
 from assemblix_api.execution.debug_event_manager import DebugEventManager
 from assemblix_api.execution.voice_gate import (
     ensure_audio_run_is_synchronous,
+    load_audio_from_base64,
     load_audio_into_input_data,
 )
 from assemblix_api.queue.enqueue import enqueue_execution
@@ -529,6 +530,16 @@ async def execute_workflow(
 
     input_data = _build_input_data(request, is_debug=False)
 
+    audio_input = None
+    if request.audio_base64:
+        audio_input = load_audio_from_base64(
+            workflow=workflow,
+            input_data=input_data,
+            audio_base64=request.audio_base64,
+            mime=request.audio_mime,
+            filename=request.audio_filename,
+        )
+
     return await _dispatch_sync(
         workflow,
         input_data,
@@ -537,6 +548,7 @@ async def execute_workflow(
         token_id=token_id,
         execution_service=execution_service,
         session=session,
+        audio_input=audio_input,
     )
 
 
@@ -579,12 +591,23 @@ async def execute_workflow_debug(
 
     input_data = _build_input_data(request, is_debug=True)
 
+    audio_input = None
+    if request.audio_base64:
+        audio_input = load_audio_from_base64(
+            workflow=workflow,
+            input_data=input_data,
+            audio_base64=request.audio_base64,
+            mime=request.audio_mime,
+            filename=request.audio_filename,
+        )
+
     return _dispatch_debug_stream(
         workflow,
         input_data,
         session_id=request.session_id,
         token_id=token_id,
         debug_event_manager=debug_event_manager,
+        audio_input=audio_input,
     )
 
 

--- a/assemblix-app-api/assemblix_api/dto/requests/execution.py
+++ b/assemblix-app-api/assemblix_api/dto/requests/execution.py
@@ -51,6 +51,18 @@ class ExecuteWorkflowRequest(DTOModel):
         default=False,
         description="If true, stream text deltas from streamable agent nodes over SSE (subscribe via GET /executions/{id}/stream)",
     )
+    audio_base64: str | None = Field(
+        default=None,
+        description="Inbound audio as base64 (alternative to multipart /execute/audio). START node must accept voice",
+    )
+    audio_mime: str | None = Field(
+        default=None,
+        description="MIME type of audioBase64 (e.g. 'audio/wav', 'audio/mpeg'). Defaults to audio/wav",
+    )
+    audio_filename: str | None = Field(
+        default=None,
+        description="Optional original filename for the base64 audio",
+    )
 
 
 class ExecutionFilters(DTOModel):

--- a/assemblix-app-api/assemblix_api/execution/agent_runner.py
+++ b/assemblix-app-api/assemblix_api/execution/agent_runner.py
@@ -33,6 +33,7 @@ from pydantic_ai.settings import ModelSettings
 
 from assemblix_api.execution.exceptions import AgentRunTimeoutError
 from assemblix_api.external.llm.base import TokenUsage
+from assemblix_api.external.llm.litellm_model import collect_response_cost
 from assemblix_api.external.llm.pricing import compute_cost
 from assemblix_api.schemas.execution import AgentExecutionResult
 
@@ -156,13 +157,16 @@ class AgentRunner:
             model_settings=model_settings,
             event_stream_handler=event_stream_handler,
         )
-        try:
-            if total_timeout is not None:
-                result = await asyncio.wait_for(run_coro, timeout=total_timeout)
-            else:
-                result = await run_coro
-        except TimeoutError as exc:
-            raise AgentRunTimeoutError(f"Agent run exceeded its {total_timeout}s budget") from exc
+        with collect_response_cost() as response_costs:
+            try:
+                if total_timeout is not None:
+                    result = await asyncio.wait_for(run_coro, timeout=total_timeout)
+                else:
+                    result = await run_coro
+            except TimeoutError as exc:
+                raise AgentRunTimeoutError(
+                    f"Agent run exceeded its {total_timeout}s budget"
+                ) from exc
 
         content = result.output if isinstance(result.output, str) else str(result.output)
 
@@ -180,7 +184,10 @@ class AgentRunner:
             output_tokens=usage.output_tokens or 0,
             total_tokens=usage.total_tokens or 0,
         )
-        cost = compute_cost(provider, model_name, token_usage)
+        # litellm's own cost (summed across the run's completions) is authoritative
+        # when present; otherwise compute_cost falls back to registry prices.
+        native_cost = sum(response_costs) if response_costs else None
+        cost = compute_cost(provider, model_name, token_usage, native_cost=native_cost)
 
         all_messages = result.all_messages()
         tool_executions = _extract_tool_executions(all_messages)

--- a/assemblix-app-api/assemblix_api/execution/voice_gate.py
+++ b/assemblix-app-api/assemblix_api/execution/voice_gate.py
@@ -9,6 +9,9 @@ execution context — transcription is NO LONGER done here, it is an explicit
 
 from __future__ import annotations
 
+import base64
+import binascii
+
 from fastapi import HTTPException, UploadFile, status
 
 from assemblix_api.core.settings import get_settings
@@ -24,23 +27,15 @@ def ensure_audio_run_is_synchronous(*, input_data: dict, queued: bool) -> None:
         raise ValueError("Audio input is only supported on synchronous runs")
 
 
-async def load_audio_into_input_data(
-    *,
+def _finalize_audio_input(
     workflow: Workflow,
     input_data: dict,
-    file: UploadFile,
+    *,
+    audio_bytes: bytes,
+    filename: str,
+    mime: str,
 ) -> AudioInput:
-    """Validate + load the inbound audio blob into the run.
-
-    Sets ``input_data["message"] = ""`` and ``input_data["input_type"] = "audio"``,
-    and returns the bytes as an ``AudioInput`` for the caller to attach to the
-    execution context. Transcription is NO LONGER done here — it is an explicit
-    ``transcribe`` node.
-
-    Raises:
-        HTTPException(400): the START node does not accept voice.
-        HTTPException(413): the audio exceeds ``voice_max_upload_bytes``.
-    """
+    """Validate the START voice flag + size cap, mutate input_data, return AudioInput."""
     start_id = GraphNavigator.find_start_node(workflow.nodes)
     start_node = next((n for n in workflow.nodes if n["id"] == start_id), None)
     start_cfg = StartNodeConfig(**((start_node or {}).get("config") or {}))
@@ -51,15 +46,11 @@ async def load_audio_into_input_data(
         )
 
     max_bytes = get_settings().voice_max_upload_bytes
-    audio_bytes = await file.read(max_bytes + 1)
     if len(audio_bytes) > max_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             detail="Audio file is too large",
         )
-
-    filename = file.filename or "voice.wav"
-    mime = getattr(file, "content_type", None) or "audio/wav"
 
     input_data["message"] = ""
     input_data["input_type"] = "audio"
@@ -67,3 +58,54 @@ async def load_audio_into_input_data(
     # CEL/authors can see `input.audio` on audio runs.
     input_data["audio"] = {"filename": filename, "mime": mime}
     return AudioInput(bytes=audio_bytes, mime=mime, filename=filename)
+
+
+async def load_audio_into_input_data(
+    *,
+    workflow: Workflow,
+    input_data: dict,
+    file: UploadFile,
+) -> AudioInput:
+    """Validate + load the inbound multipart audio blob into the run.
+
+    Sets ``input_data["message"] = ""`` and ``input_data["input_type"] = "audio"``,
+    and returns the bytes as an ``AudioInput`` for the caller to attach to the
+    execution context. Transcription is NO LONGER done here — it is an explicit
+    ``transcribe`` node.
+
+    Raises:
+        HTTPException(400): the START node does not accept voice.
+        HTTPException(413): the audio exceeds ``voice_max_upload_bytes``.
+    """
+    max_bytes = get_settings().voice_max_upload_bytes
+    audio_bytes = await file.read(max_bytes + 1)
+    filename = file.filename or "voice.wav"
+    mime = getattr(file, "content_type", None) or "audio/wav"
+    return _finalize_audio_input(
+        workflow, input_data, audio_bytes=audio_bytes, filename=filename, mime=mime
+    )
+
+
+def load_audio_from_base64(
+    *,
+    workflow: Workflow,
+    input_data: dict,
+    audio_base64: str,
+    mime: str | None,
+    filename: str | None,
+) -> AudioInput:
+    """Decode a base64 audio payload from a JSON body, then finalize it."""
+    try:
+        audio_bytes = base64.b64decode(audio_base64, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="audioBase64 is not valid base64",
+        ) from exc
+    return _finalize_audio_input(
+        workflow,
+        input_data,
+        audio_bytes=audio_bytes,
+        filename=filename or "voice.wav",
+        mime=mime or "audio/wav",
+    )

--- a/assemblix-app-api/assemblix_api/external/llm/litellm_model.py
+++ b/assemblix-app-api/assemblix_api/external/llm/litellm_model.py
@@ -13,7 +13,10 @@ but pydantic-ai requires exactly that → we revalidate via `.model_validate(res
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import os
+from collections.abc import Iterator
 from typing import Any, cast
 
 import litellm
@@ -28,6 +31,37 @@ from assemblix_api.external.llm.provider_config import get_provider_config
 # litellm must not flood our logs with debug output.
 litellm.set_verbose = False
 litellm.suppress_debug_info = True
+
+# Per-run accumulator for litellm's own cost figure (`response_cost` in
+# `_hidden_params`). The shim revalidates the litellm response into an OpenAI
+# ChatCompletion, which drops `_hidden_params`, so we capture the cost here and
+# hand the sum to AgentRunner. A ContextVar isolates concurrent runs; the same
+# bucket is shared across every completion of one run (tool loop + FallbackModel).
+_response_cost_var: contextvars.ContextVar[list[float] | None] = contextvars.ContextVar(
+    "litellm_response_cost", default=None
+)
+
+
+@contextlib.contextmanager
+def collect_response_cost() -> Iterator[list[float]]:
+    """Collect per-completion litellm costs for the duration of one agent run."""
+    bucket: list[float] = []
+    token = _response_cost_var.set(bucket)
+    try:
+        yield bucket
+    finally:
+        _response_cost_var.reset(token)
+
+
+def _record_response_cost(resp: object) -> None:
+    """Append litellm's `response_cost` to the active bucket, if any and positive."""
+    bucket = _response_cost_var.get()
+    if bucket is None:
+        return
+    hidden = getattr(resp, "_hidden_params", None) or {}
+    cost = hidden.get("response_cost") if isinstance(hidden, dict) else None
+    if isinstance(cost, (int, float)) and cost > 0:
+        bucket.append(float(cost))
 
 
 def _strip_sentinels(kwargs: dict[str, Any]) -> dict[str, Any]:
@@ -64,6 +98,8 @@ class _Completions:
             # the object. litellm's CustomStreamWrapper has none of those, so wrap it.
             return _StreamShim(await litellm.acompletion(**merged))
         resp = await litellm.acompletion(**merged)
+        # Capture litellm's own cost before revalidation drops `_hidden_params`.
+        _record_response_cost(resp)
         # litellm.ModelResponse → real openai ChatCompletion (pydantic-ai isinstance check).
         # warnings=False: the litellm schema is slightly wider than the openai types; without
         # this it emits UserWarning.
@@ -96,6 +132,10 @@ class _StreamShim:
         return ChatCompletionChunk.model_validate(chunk.model_dump(warnings=False))
 
     async def close(self) -> None:
+        # Best-effort: litellm may attach `response_cost` to the wrapper after the
+        # stream is drained. If absent, nothing is recorded and cost falls back to
+        # the registry prices in compute_cost.
+        _record_response_cost(self._stream)
         aclose = getattr(self._stream, "aclose", None)
         if aclose is not None:
             await aclose()

--- a/assemblix-app-api/assemblix_api/external/llm/models/openai.json
+++ b/assemblix-app-api/assemblix_api/external/llm/models/openai.json
@@ -290,6 +290,30 @@
       "inputCostPerMillion": 10.0,
       "outputCostPerMillion": 30.0,
       "capabilities": {}
+    },
+    {
+      "id": "gpt-audio",
+      "label": "GPT Audio",
+      "description": "Audio-in, text-out. Accepts speech natively; pair with a voice-enabled START node.",
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "inputCostPerMillion": 2.5,
+      "outputCostPerMillion": 10.0,
+      "capabilities": {
+        "accepts_audio": true
+      }
+    },
+    {
+      "id": "gpt-audio-mini",
+      "label": "GPT Audio Mini",
+      "description": "Cheaper audio-in, text-out model for simpler voice turns.",
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "inputCostPerMillion": 0.6,
+      "outputCostPerMillion": 2.4,
+      "capabilities": {
+        "accepts_audio": true
+      }
     }
   ]
 }


### PR DESCRIPTION
## Что и зачем

Две независимые доработки voice-нод (можно ревьюить/мёржить по-отдельности по коммитам).

### 1. gpt-audio как дополнительная аудио-модель + корректный биллинг
- `gpt-audio` / `gpt-audio-mini` добавлены в OpenAI-каталог с `accepts_audio` → выбираются везде, где доступны модели OpenAI; аудио-гейт agent-ноды их пропускает. Gemini остаётся — это **дополнение**, не замена.
- Транспорт не менялся: аудио уже уходит `BinaryContent`, litellm мапит его в нативный OpenAI `input_audio`.
- **Биллинг:** аудио-токены gpt-audio (~$32/$64 за 1M) кратно дороже текстовых, а `usage.input_tokens` — одно суммарное число, поэтому одна пара цен неверна. Перехватываем `response_cost` от litellm в транспортном шиме через per-run ContextVar-аккумулятор (сумма по всем completion'ам прогона: tool-loop + FallbackModel) и передаём как `native_cost` в `compute_cost`. При отсутствии native-cost — fallback на цены из каталога. Побочно чинит точность стоимости для **всех** провайдеров.

### 2. base64-вход для аудио
- Новые опциональные поля `audioBase64` / `audioMime` / `audioFilename` в `ExecuteWorkflowRequest` — аудио можно слать обычным JSON на `/execute` и `/execute/debug`, без multipart.
- Общая валидация (`accept_voice` 400, `voiceMaxUploadBytes` 413) вынесена в `_finalize_audio_input`, переиспользуется multipart- и base64-путями. Кап применяется к **декодированным** байтам.
- Multipart-путь поведенчески не изменён.

## Вне scope (YAGNI)
Аудио-выход самой gpt-audio (голос через ElevenLabs), OpenAI Realtime API (другой транспорт), отдельные поля цен по типам токенов (native-cost их заменяет).

## Проверки
- `make check` — **297 passed**, покрытие 70.23% (порог 60%).
- `ruff format` + `ruff check` чистые.
- Новые тесты в этом PR **не добавлялись** намеренно; регрессии закрыты существующим сьютом. Готовые тест-кейсы (a)–(f) описаны в internal-спеке/плане на будущее.

## Известные ограничения
- Стриминговый `response_cost` — best-effort: если litellm не отдаёт его на stream-wrapper'е, стрим биллится по каталожному fallback (не \$0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)