### PR TITLE
fix(voice): list all ElevenLabs voices via v2 endpoint with search

### DIFF
--- a/assemblix-app-api/assemblix_api/api/rest/voice.py
+++ b/assemblix-app-api/assemblix_api/api/rest/voice.py
@@ -76,14 +76,15 @@ async def list_provider_models(
 @router.get("/credentials/{credentials_id}/voices", response_model=list[VoiceListItem])
 async def list_credential_voices(
     credentials_id: UUID,
+    search: str | None = Query(default=None, description="Filter ElevenLabs voices"),
     auth: AuthContext = Depends(get_auth_context),
     credentials_service: CredentialsService = Depends(get_credentials_service),
     project_service: ProjectService = Depends(get_project_service),
 ) -> list[VoiceListItem]:
     """List the voices available to a stored voice credential.
 
-    ElevenLabs voices are fetched live per key; Yandex SpeechKit has a fixed
-    catalog and needs no API call.
+    ElevenLabs voices are fetched live per key (paginated, optional server-side
+    ``search``); Yandex SpeechKit has a fixed catalog and needs no API call.
     """
     credentials = await credentials_service.get_by_id(credentials_id)
     await project_service.authorize_project_access(auth, credentials.project_id)
@@ -101,13 +102,14 @@ async def list_credential_voices(
     api_key = await credentials_service.get_decrypted_api_key(
         credentials_id, credentials.project_id
     )
-    voices = await list_voices(api_key)
+    voices = await list_voices(api_key, search=search)
     return [VoiceListItem(id=v.id, name=v.name, preview_url=v.preview_url) for v in voices]
 
 
 @router.get("/providers/{provider_name}/system-voices", response_model=list[VoiceListItem])
 async def list_system_voices(
     provider_name: str,
+    search: str | None = Query(default=None, description="Filter ElevenLabs voices"),
     current_user: User = Depends(get_current_user),
 ) -> list[VoiceListItem]:
     """List the voices available to the platform's system key for a voice provider.
@@ -132,5 +134,5 @@ async def list_system_voices(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="System voice key is not configured",
         )
-    voices = await list_voices(api_key)
+    voices = await list_voices(api_key, search=search)
     return [VoiceListItem(id=v.id, name=v.name, preview_url=v.preview_url) for v in voices]

--- a/assemblix-app-api/assemblix_api/external/voice/elevenlabs.py
+++ b/assemblix-app-api/assemblix_api/external/voice/elevenlabs.py
@@ -20,6 +20,24 @@ def _base_url() -> str:
     return get_settings().elevenlabs_api_base_url.rstrip("/")
 
 
+def _voices_url() -> str:
+    """URL for the v2 voice-listing endpoint.
+
+    Voice listing uses ``/v2/voices`` (paginated + server-side search); the
+    configured base URL points at ``/v1`` (still used for TTS), so swap the
+    trailing version segment.
+    """
+    base = _base_url()
+    if base.endswith("/v1"):
+        base = f"{base[:-3]}/v2"
+    return f"{base}/voices"
+
+
+def _client() -> httpx.AsyncClient:
+    """Factory kept as a seam so tests can inject a MockTransport."""
+    return httpx.AsyncClient(timeout=_TIMEOUT)
+
+
 class ElevenLabsVoice(BaseModel):
     """One voice from the account's voice library."""
 
@@ -28,21 +46,43 @@ class ElevenLabsVoice(BaseModel):
     preview_url: str | None = None
 
 
-async def list_voices(api_key: str) -> list[ElevenLabsVoice]:
-    """Return the voices available to ``api_key`` (GET /v1/voices)."""
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.get(f"{_base_url()}/voices", headers={"xi-api-key": api_key})
-        resp.raise_for_status()
-        data = resp.json()
-    return [
-        ElevenLabsVoice(id=v["voice_id"], name=v["name"], preview_url=v.get("preview_url"))
-        for v in data.get("voices", [])
-    ]
+async def list_voices(api_key: str, *, search: str | None = None) -> list[ElevenLabsVoice]:
+    """Return the voices available to ``api_key`` (GET /v2/voices).
+
+    The legacy ``/v1/voices`` endpoint returns only a truncated default set; v2
+    paginates the full library (max 100/page) and supports a server-side
+    ``search`` over name/description/labels/category, which is forwarded here.
+    All pages are drained so the caller gets every matching voice.
+    """
+    voices: list[ElevenLabsVoice] = []
+    page_token: str | None = None
+    async with _client() as client:
+        while True:
+            params: dict[str, str | int] = {"page_size": 100}
+            if search:
+                params["search"] = search
+            if page_token:
+                params["next_page_token"] = page_token
+            resp = await client.get(
+                _voices_url(), headers={"xi-api-key": api_key}, params=params
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            voices.extend(
+                ElevenLabsVoice(
+                    id=v["voice_id"], name=v["name"], preview_url=v.get("preview_url")
+                )
+                for v in data.get("voices", [])
+            )
+            page_token = data.get("next_page_token")
+            if not data.get("has_more") or not page_token:
+                break
+    return voices
 
 
 async def synthesize(*, api_key: str, voice_id: str, model: str, text: str) -> bytes:
     """Synthesize ``text`` with ``voice_id`` and return MP3 bytes."""
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+    async with _client() as client:
         resp = await client.post(
             f"{_base_url()}/text-to-speech/{voice_id}",
             headers={"xi-api-key": api_key, "accept": "audio/mpeg"},

--- a/assemblix-app-api/assemblix_api/external/voice/elevenlabs.py
+++ b/assemblix-app-api/assemblix_api/external/voice/elevenlabs.py
@@ -63,15 +63,11 @@ async def list_voices(api_key: str, *, search: str | None = None) -> list[Eleven
                 params["search"] = search
             if page_token:
                 params["next_page_token"] = page_token
-            resp = await client.get(
-                _voices_url(), headers={"xi-api-key": api_key}, params=params
-            )
+            resp = await client.get(_voices_url(), headers={"xi-api-key": api_key}, params=params)
             resp.raise_for_status()
             data = resp.json()
             voices.extend(
-                ElevenLabsVoice(
-                    id=v["voice_id"], name=v["name"], preview_url=v.get("preview_url")
-                )
+                ElevenLabsVoice(id=v["voice_id"], name=v["name"], preview_url=v.get("preview_url"))
                 for v in data.get("voices", [])
             )
             page_token = data.get("next_page_token")

--- a/assemblix-app-api/tests/integration/test_voice_endpoints.py
+++ b/assemblix-app-api/tests/integration/test_voice_endpoints.py
@@ -44,7 +44,7 @@ async def test_list_credential_voices(client, auth_user, auth_headers, mocker) -
     # Arrange
     cred_id = await _create_eleven_credential(client, auth_user, auth_headers)
 
-    async def _fake_list(api_key):
+    async def _fake_list(api_key, *, search=None):
         from assemblix_api.external.voice.elevenlabs import ElevenLabsVoice
 
         return [ElevenLabsVoice(id="v1", name="Rachel")]
@@ -80,7 +80,7 @@ async def test_system_voices_lists_platform_voices(
     # Arrange
     monkeypatch.setattr(get_settings(), "system_elevenlabs_api_key", "xi-system")
 
-    async def _fake_list(api_key):
+    async def _fake_list(api_key, *, search=None):
         from assemblix_api.external.voice.elevenlabs import ElevenLabsVoice
 
         return [ElevenLabsVoice(id="sv1", name="Platform Voice")]

--- a/assemblix-app-api/tests/unit/test_elevenlabs_adapter.py
+++ b/assemblix-app-api/tests/unit/test_elevenlabs_adapter.py
@@ -1,0 +1,83 @@
+import httpx
+import pytest
+
+from assemblix_api.external.voice import elevenlabs
+
+
+@pytest.mark.asyncio
+async def test_list_voices_hits_v2_and_requests_max_page_size(monkeypatch):
+    # The v1 legacy endpoint returns a truncated default set; v2/voices paginates
+    # (page_size max 100) and exposes the full library.
+    captured = {}
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url).split("?")[0]
+        captured["params"] = dict(request.url.params)
+        captured["api_key"] = request.headers.get("xi-api-key")
+        return httpx.Response(
+            200,
+            json={
+                "voices": [
+                    {"voice_id": "v1", "name": "Aurora", "preview_url": "http://p/1"},
+                    {"voice_id": "v2", "name": "Leo"},
+                ],
+                "has_more": False,
+            },
+        )
+
+    transport = httpx.MockTransport(_handler)
+    monkeypatch.setattr(elevenlabs, "_client", lambda: httpx.AsyncClient(transport=transport))
+
+    voices = await elevenlabs.list_voices("xi-key")
+
+    assert [(v.id, v.name, v.preview_url) for v in voices] == [
+        ("v1", "Aurora", "http://p/1"),
+        ("v2", "Leo", None),
+    ]
+    assert captured["url"].endswith("/v2/voices")
+    assert captured["params"]["page_size"] == "100"
+    assert captured["api_key"] == "xi-key"
+
+
+@pytest.mark.asyncio
+async def test_list_voices_follows_pagination(monkeypatch):
+    # has_more + next_page_token drive a follow-up request until the library is drained.
+    pages = iter(
+        [
+            {
+                "voices": [{"voice_id": "a", "name": "A"}],
+                "has_more": True,
+                "next_page_token": "tok-2",
+            },
+            {"voices": [{"voice_id": "b", "name": "B"}], "has_more": False},
+        ]
+    )
+    seen_tokens = []
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        seen_tokens.append(request.url.params.get("next_page_token"))
+        return httpx.Response(200, json=next(pages))
+
+    transport = httpx.MockTransport(_handler)
+    monkeypatch.setattr(elevenlabs, "_client", lambda: httpx.AsyncClient(transport=transport))
+
+    voices = await elevenlabs.list_voices("xi-key")
+
+    assert [v.id for v in voices] == ["a", "b"]
+    assert seen_tokens == [None, "tok-2"]
+
+
+@pytest.mark.asyncio
+async def test_list_voices_forwards_search(monkeypatch):
+    captured = {}
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"voices": [], "has_more": False})
+
+    transport = httpx.MockTransport(_handler)
+    monkeypatch.setattr(elevenlabs, "_client", lambda: httpx.AsyncClient(transport=transport))
+
+    await elevenlabs.list_voices("xi-key", search="aur")
+
+    assert captured["params"]["search"] == "aur"

--- a/assemblix-app-web/src/entities/voice-model/api/voice-model.api.ts
+++ b/assemblix-app-web/src/entities/voice-model/api/voice-model.api.ts
@@ -17,10 +17,12 @@ interface GetVoiceModelsParams {
 
 interface GetCredentialVoicesParams {
   credentialId: string;
+  search?: string;
 }
 
 interface GetSystemVoicesParams {
   providerName: string;
+  search?: string;
 }
 
 export const voiceModelApi = baseApi.injectEndpoints({
@@ -51,22 +53,24 @@ export const voiceModelApi = baseApi.injectEndpoints({
     }),
 
     getCredentialVoices: build.query<VoiceListItem[], GetCredentialVoicesParams>({
-      query: ({ credentialId }) => ({
+      query: ({ credentialId, search }) => ({
         url: `/voice/credentials/${credentialId}/voices`,
         method: "GET",
+        params: search ? { search } : undefined,
       }),
-      providesTags: (_result, _error, { credentialId }) => [
-        { type: "VoiceModels", id: `voices:${credentialId}` },
+      providesTags: (_result, _error, { credentialId, search }) => [
+        { type: "VoiceModels", id: `voices:${credentialId}:${search ?? ""}` },
       ],
     }),
 
     getSystemVoices: build.query<VoiceListItem[], GetSystemVoicesParams>({
-      query: ({ providerName }) => ({
+      query: ({ providerName, search }) => ({
         url: `/voice/providers/${providerName}/system-voices`,
         method: "GET",
+        params: search ? { search } : undefined,
       }),
-      providesTags: (_result, _error, { providerName }) => [
-        { type: "VoiceModels", id: `system-voices:${providerName}` },
+      providesTags: (_result, _error, { providerName, search }) => [
+        { type: "VoiceModels", id: `system-voices:${providerName}:${search ?? ""}` },
       ],
     }),
   }),

--- a/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/node-forms/voice-output-picker.tsx
+++ b/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/node-forms/voice-output-picker.tsx
@@ -155,12 +155,10 @@ export const VoiceOutputPicker = ({
   // Server-side search returns the full library; keep the selected voice
   // renderable even when it falls outside the current search results so the
   // trigger doesn't blank out and the selection isn't lost.
-  const displayedVoices = useMemo(() => {
-    if (value?.voiceId && !availableVoices.some((v) => v.id === value.voiceId)) {
-      return [{ id: value.voiceId, name: value.voiceId }, ...availableVoices];
-    }
-    return availableVoices;
-  }, [availableVoices, value?.voiceId]);
+  const displayedVoices =
+    value?.voiceId && !availableVoices.some((v) => v.id === value.voiceId)
+      ? [{ id: value.voiceId, name: value.voiceId }, ...availableVoices]
+      : availableVoices;
 
   return (
     <div className="space-y-3">

--- a/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/node-forms/voice-output-picker.tsx
+++ b/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/node-forms/voice-output-picker.tsx
@@ -5,6 +5,7 @@ import { Search } from "lucide-react";
 import { Label } from "@/shared/ui/label";
 import { Input } from "@/shared/ui/input";
 import { Switch } from "@/shared/ui/switch";
+import { useDebouncedValue } from "@/shared/lib/use-debounced-value";
 import {
   Select,
   SelectContent,
@@ -48,6 +49,7 @@ export const VoiceOutputPicker = ({
 }: VoiceOutputPickerProps) => {
   const { t } = useTranslation();
   const [voiceSearchQuery, setVoiceSearchQuery] = useState("");
+  const debouncedVoiceSearch = useDebouncedValue(voiceSearchQuery, 300);
 
   const provider = value?.provider;
   const realtime = value?.realtime ?? false;
@@ -113,7 +115,10 @@ export const VoiceOutputPicker = ({
     );
   const { data: credentialVoices = [], isLoading: isLoadingCredentialVoices } =
     useGetCredentialVoicesQuery(
-      { credentialId: value?.credentialId ?? "" },
+      {
+        credentialId: value?.credentialId ?? "",
+        search: debouncedVoiceSearch.trim() || undefined,
+      },
       { skip: !value?.credentialId },
     );
 
@@ -136,7 +141,10 @@ export const VoiceOutputPicker = ({
     Boolean(provider) && !value?.credentialId && hasVoiceSystemKey;
   const { data: systemVoices = [], isLoading: isLoadingSystemVoices } =
     useGetSystemVoicesQuery(
-      { providerName: provider ?? "" },
+      {
+        providerName: provider ?? "",
+        search: debouncedVoiceSearch.trim() || undefined,
+      },
       { skip: !usingSystemKey },
     );
   const availableVoices = value?.credentialId ? credentialVoices : systemVoices;
@@ -144,11 +152,15 @@ export const VoiceOutputPicker = ({
     ? isLoadingCredentialVoices
     : isLoadingSystemVoices;
 
-  const filteredVoices = useMemo(() => {
-    if (!voiceSearchQuery.trim()) return availableVoices;
-    const query = voiceSearchQuery.toLowerCase();
-    return availableVoices.filter((v) => v.name.toLowerCase().includes(query));
-  }, [availableVoices, voiceSearchQuery]);
+  // Server-side search returns the full library; keep the selected voice
+  // renderable even when it falls outside the current search results so the
+  // trigger doesn't blank out and the selection isn't lost.
+  const displayedVoices = useMemo(() => {
+    if (value?.voiceId && !availableVoices.some((v) => v.id === value.voiceId)) {
+      return [{ id: value.voiceId, name: value.voiceId }, ...availableVoices];
+    }
+    return availableVoices;
+  }, [availableVoices, value?.voiceId]);
 
   return (
     <div className="space-y-3">
@@ -249,32 +261,32 @@ export const VoiceOutputPicker = ({
               sideOffset={5}
               align="end"
             >
-              {availableVoices.length > 0 && (
-                <div className="sticky top-0 z-10 bg-popover p-2 border-b">
-                  <div className="relative">
-                    <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-                    <Input
-                      placeholder={t("nodeForms.end.searchVoice")}
-                      value={voiceSearchQuery}
-                      onChange={(e) => setVoiceSearchQuery(e.target.value)}
-                      className="pl-8 h-8 text-xs"
-                      onClick={(e) => e.stopPropagation()}
-                      onKeyDown={(e) => e.stopPropagation()}
-                    />
-                  </div>
+              <div className="sticky top-0 z-10 bg-popover p-2 border-b">
+                <div className="relative">
+                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+                  <Input
+                    placeholder={t("nodeForms.end.searchVoice")}
+                    value={voiceSearchQuery}
+                    onChange={(e) => setVoiceSearchQuery(e.target.value)}
+                    className="pl-8 h-8 text-xs"
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
+                  />
                 </div>
-              )}
+              </div>
               <div className="overflow-y-auto flex-1 min-h-0">
-                {availableVoices.length === 0 && !isLoadingVoices ? (
+                {isLoadingVoices ? (
                   <div className="px-2 py-1.5 text-xs text-muted-foreground">
-                    {t("nodeForms.end.noVoices")}
+                    {t("nodeForms.end.loadingVoices")}
                   </div>
-                ) : filteredVoices.length === 0 ? (
+                ) : displayedVoices.length === 0 ? (
                   <div className="px-2 py-1.5 text-xs text-muted-foreground">
-                    {t("nodeForms.end.noVoicesFound")}
+                    {debouncedVoiceSearch.trim()
+                      ? t("nodeForms.end.noVoicesFound")
+                      : t("nodeForms.end.noVoices")}
                   </div>
                 ) : (
-                  filteredVoices.map((v) => (
+                  displayedVoices.map((v) => (
                     <SelectItem key={v.id} value={v.id} className="text-xs">
                       {v.name}
                     </SelectItem>


### PR DESCRIPTION
## Проблема

В пикере голосов ElevenLabs приезжал только усечённый набор (~21 голос), хотя в веб-интерфейсе ElevenLabs их значительно больше. Причина — `list_voices` дёргала легаси-эндпоинт `GET /v1/voices`, который отдаёт только дефолтный набор, не видит всю библиотеку «My Voices» и не поддерживает серверный поиск. Поиск в пикере при этом был клиентским — фильтровал лишь по этим 21 голосу.

## Решение (по паттерну anam voice adapter)

**Backend**
- `list_voices` переведён на `GET /v2/voices` с `page_size=100` и полной пагинацией через `next_page_token`/`has_more` — тянет всю библиотеку.
- Проброс опционального `search` (по name/description/labels/category) в адаптер и в REST-ручки `list_credential_voices` / `list_system_voices`.
- Добавлены `_voices_url()` (свап `/v1`→`/v2`; TTS `synthesize` остаётся на v1) и `_client()`-seam для тестов.

**Frontend**
- `search` в RTK Query `getCredentialVoices` / `getSystemVoices` (+ в cache-tag).
- Клиентская фильтрация в `voice-output-picker` заменена на серверный поиск с дебаунсом 300ms; выбранный голос остаётся видимым, даже если выпал из результатов поиска.

## Тесты
- Новый `test_elevenlabs_adapter.py`: проверяет v2-URL, `page_size=100`, пагинацию и проброс `search`.
- Обновлены моки в `test_voice_endpoints.py` под новую сигнатуру.

Все тесты зелёные (13 passed), фронт `tsc --noEmit` чистый, ruff/mypy без замечаний.

🤖 Generated with [Claude Code](https://claude.com/claude-code)