### PR TITLE
feat(voice): Yandex SpeechKit v3 realtime TTS for avatar lip-sync

### DIFF
--- a/assemblix-app-api/assemblix_api/core/settings.py
+++ b/assemblix-app-api/assemblix_api/core/settings.py
@@ -241,6 +241,11 @@ class Settings(BaseSettings):
     yandex_stt_api_base_url: str = os.getenv(
         "YANDEX_STT_API_BASE_URL", "https://stt.api.cloud.yandex.net/speech/v1"
     )
+    # SpeechKit v3 realtime synthesis is gRPC ("host:port"), not REST. Override for a
+    # proxy/gateway.
+    yandex_tts_v3_grpc_endpoint: str = os.getenv(
+        "YANDEX_TTS_V3_GRPC_ENDPOINT", "tts.api.cloud.yandex.net:443"
+    )
 
     @field_validator("voice_realtime_chunk_schedule", mode="before")
     @classmethod

--- a/assemblix-app-api/assemblix_api/external/voice/models/yandex.json
+++ b/assemblix-app-api/assemblix_api/external/voice/models/yandex.json
@@ -14,6 +14,22 @@
       "description": "Yandex SpeechKit short-audio speech recognition (≤ 1 MB / 30 s).",
       "capability": "transcription",
       "route": "transcription"
+    },
+    {
+      "id": "yandex-tts-v3",
+      "label": "SpeechKit v3 (Realtime, natural intonation)",
+      "description": "Yandex SpeechKit v3 realtime streaming, synthesized sentence-by-sentence for the most natural Russian prosody.",
+      "capability": "realtime",
+      "route": "realtime",
+      "cost_per_char": 0.0000075
+    },
+    {
+      "id": "yandex-tts-v3-stream",
+      "label": "SpeechKit v3 (Realtime, low latency)",
+      "description": "Yandex SpeechKit v3 bidirectional streaming for the lowest time-to-first-audio.",
+      "capability": "realtime",
+      "route": "realtime",
+      "cost_per_char": 0.0000075
     }
   ]
 }

--- a/assemblix-app-api/assemblix_api/external/voice/realtime_dispatch.py
+++ b/assemblix-app-api/assemblix_api/external/voice/realtime_dispatch.py
@@ -1,0 +1,59 @@
+"""Realtime (streaming) TTS provider seam — sibling of ``synthesis.py``.
+
+The realtime path was ElevenLabs-only; this factory picks the session class per
+provider, keeping the agent node transport-agnostic. Each session shares the same
+duck-typed contract (``RealtimeSession``): ``open() / send_text() / flush_and_close()``
+plus an ``on_audio(pcm, alignment)`` callback wired at construction.
+
+For Yandex the *model id* also selects the streaming mode (see ``_YANDEX_MODEL_MODE``),
+so the existing model picker doubles as the mode switch — no extra config field.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from assemblix_api.external.voice.realtime import OnAudio, RealtimeTTSSession
+from assemblix_api.external.voice.yandex_realtime import Mode, YandexRealtimeSession
+
+
+class RealtimeSession(Protocol):
+    async def open(self) -> None: ...
+    async def send_text(self, text: str) -> None: ...
+    async def flush_and_close(self) -> int: ...
+
+
+# Yandex catalog id → streaming mode. "utterance" = sentence-buffered (best prosody);
+# "stream" = bidirectional (lowest latency).
+_YANDEX_MODEL_MODE: dict[str, Mode] = {
+    "yandex-tts-v3": "utterance",
+    "yandex-tts-v3-stream": "stream",
+}
+
+
+def create_realtime_session(
+    *,
+    provider: str,
+    api_key: str,
+    voice_id: str,
+    model: str,
+    on_audio: OnAudio,
+) -> RealtimeSession:
+    """Build the realtime TTS session for ``provider``.
+
+    Raises:
+        NotImplementedError: the provider has no realtime route.
+    """
+    if provider == "elevenlabs":
+        return RealtimeTTSSession(
+            api_key=api_key, voice_id=voice_id, model=model, on_audio=on_audio
+        )
+    if provider == "yandex":
+        return YandexRealtimeSession(
+            credential=api_key,
+            voice_id=voice_id,
+            model=model,
+            on_audio=on_audio,
+            mode=_YANDEX_MODEL_MODE.get(model, "utterance"),
+        )
+    raise NotImplementedError(f"No realtime route for provider {provider!r}")

--- a/assemblix-app-api/assemblix_api/external/voice/yandex_realtime.py
+++ b/assemblix-app-api/assemblix_api/external/voice/yandex_realtime.py
@@ -1,0 +1,212 @@
+"""Yandex SpeechKit v3 realtime text-to-speech over gRPC.
+
+The sibling of ``realtime.py`` (ElevenLabs) for the avatar / realtime-voice path. It
+exposes the same duck-typed session contract — ``open() / send_text() / flush_and_close()``
+plus an ``on_audio(pcm, alignment)`` callback — so the agent node stays provider-agnostic.
+
+SpeechKit v3 offers two streaming RPCs, surfaced here as ``mode``:
+
+* ``"utterance"`` — buffer incoming deltas and synthesize one *whole sentence* at a time
+  (``UtteranceSynthesis``, server-streaming). Full-sentence context gives the best Russian
+  prosody; audio still flows out per sentence as the agent generates.
+* ``"stream"`` — forward each delta as it arrives (``StreamSynthesis``, bidirectional).
+  Lowest latency, at some cost to prosody on mid-sentence fragments.
+
+Both emit raw ``LINEAR16_PCM`` at 16 kHz mono — exactly what anam's audio passthrough
+expects — so no resampling is needed. Live/best-effort: a gRPC error stops audio but never
+raises out of ``send_text``/``flush_and_close``; the caller's text stream is unaffected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import re
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any, Literal
+
+import structlog
+
+from assemblix_api.core.settings import get_settings
+from assemblix_api.external.voice.yandex import split_credential
+from assemblix_api.schemas.debug_events import AlignmentData
+
+logger = structlog.get_logger(__name__)
+
+OnAudio = Callable[[bytes, AlignmentData | None], Awaitable[None]]
+
+Mode = Literal["utterance", "stream"]
+
+# anam passthrough is pcm_s16le / 16000 / mono — request exactly that from SpeechKit.
+_SAMPLE_RATE = 16000
+
+# A "complete" chunk ends on sentence-final punctuation or a newline; the trailing
+# incomplete fragment stays buffered until more text (or flush) closes it.
+_SENTENCE = re.compile(r"[^.!?…\n]*[.!?…\n]+", re.S)
+
+# Sentinel that tells a worker loop no more text is coming.
+_DONE = object()
+
+
+class YandexRealtimeSession:
+    def __init__(
+        self,
+        *,
+        credential: str,
+        voice_id: str,
+        model: str,
+        on_audio: OnAudio,
+        mode: Mode = "utterance",
+        stub: Any = None,
+    ):
+        # ``credential`` is the combined "<folderId>:<apiKey>" form; split at open().
+        self._credential = credential
+        self._voice_id = voice_id
+        self._model = model  # our catalog id (unused as a SpeechKit model name)
+        self._on_audio = on_audio
+        self._mode: Mode = mode
+        self._stub = stub  # injectable for tests; a real aio stub is built in open()
+        self._channel: Any = None
+        self._metadata: list[tuple[str, str]] = []
+        self._queue: asyncio.Queue[Any] = asyncio.Queue()
+        self._worker: asyncio.Task | None = None
+        self._buffer = ""
+        self._chars_sent = 0
+        self._failed = False
+
+    # -- lifecycle ----------------------------------------------------------------
+
+    async def open(self) -> None:
+        folder_id, api_key = split_credential(self._credential)  # raises ValueError
+        self._metadata = [
+            ("authorization", f"Api-Key {api_key}"),
+            ("x-folder-id", folder_id),
+        ]
+        if self._stub is None:
+            import grpc
+            from yandex.cloud.ai.tts.v3 import tts_service_pb2_grpc
+
+            endpoint = get_settings().yandex_tts_v3_grpc_endpoint
+            self._channel = grpc.aio.secure_channel(endpoint, grpc.ssl_channel_credentials())
+            self._stub = tts_service_pb2_grpc.SynthesizerStub(self._channel)
+
+        worker = self._utterance_worker if self._mode == "utterance" else self._stream_worker
+        self._worker = asyncio.create_task(worker())
+
+    async def send_text(self, text: str) -> None:
+        if self._failed or not text:
+            return
+        self._chars_sent += len(text)
+        if self._mode == "utterance":
+            self._buffer += text
+            for sentence in self._drain_sentences():
+                await self._queue.put(sentence)
+        else:
+            await self._queue.put(text)
+
+    async def flush_and_close(self) -> int:
+        if self._mode == "utterance" and not self._failed:
+            tail = self._buffer.strip()
+            self._buffer = ""
+            if tail:
+                await self._queue.put(tail)
+        await self._queue.put(_DONE)
+        if self._worker is not None:
+            try:
+                await asyncio.wait_for(self._worker, timeout=60.0)
+            except Exception:  # noqa: BLE001 — audio is best-effort; abandon the worker.
+                self._worker.cancel()
+        await self.aclose()
+        return self._chars_sent
+
+    async def aclose(self) -> None:
+        if self._channel is not None:
+            with contextlib.suppress(Exception):
+                await self._channel.close()
+            self._channel = None
+
+    # -- utterance mode (UtteranceSynthesis, one sentence per call) ----------------
+
+    def _drain_sentences(self) -> list[str]:
+        """Pull complete sentences out of the buffer, leaving the tail fragment."""
+        out: list[str] = []
+        last = 0
+        for m in _SENTENCE.finditer(self._buffer):
+            chunk = m.group().strip()
+            if chunk:
+                out.append(chunk)
+            last = m.end()
+        self._buffer = self._buffer[last:]
+        return out
+
+    async def _utterance_worker(self) -> None:
+        try:
+            while True:
+                item = await self._queue.get()
+                if item is _DONE:
+                    return
+                await self._synthesize_utterance(item)
+        except Exception as exc:  # noqa: BLE001 — best-effort; log and stop audio.
+            self._failed = True
+            logger.info("voice.realtime.yandex.utterance_stopped", error=str(exc))
+
+    async def _synthesize_utterance(self, text: str) -> None:
+        from yandex.cloud.ai.tts.v3 import tts_pb2
+
+        request = tts_pb2.UtteranceSynthesisRequest(
+            text=text,
+            hints=[tts_pb2.Hints(voice=self._voice_id)],
+            output_audio_spec=_audio_spec(tts_pb2),
+        )
+        async for response in self._stub.UtteranceSynthesis(request, metadata=self._metadata):
+            data = response.audio_chunk.data
+            if data:
+                await self._on_audio(data, None)
+
+    # -- stream mode (StreamSynthesis, bidirectional) -----------------------------
+
+    async def _stream_worker(self) -> None:
+        from yandex.cloud.ai.tts.v3 import tts_pb2
+
+        try:
+            responses = self._stub.StreamSynthesis(
+                self._stream_requests(tts_pb2), metadata=self._metadata
+            )
+            async for response in responses:
+                data = response.audio_chunk.data
+                if data:
+                    await self._on_audio(data, None)
+        except Exception as exc:  # noqa: BLE001 — best-effort; log and stop audio.
+            self._failed = True
+            logger.info("voice.realtime.yandex.stream_stopped", error=str(exc))
+
+    async def _stream_requests(self, tts_pb2: Any) -> AsyncIterator[Any]:
+        # First message carries the synthesis options; the rest carry text as it arrives.
+        yield tts_pb2.StreamSynthesisRequest(
+            options=tts_pb2.SynthesisOptions(
+                voice=self._voice_id,
+                output_audio_spec=_audio_spec(tts_pb2),
+            )
+        )
+        while True:
+            item = await self._queue.get()
+            if item is _DONE:
+                return
+            yield tts_pb2.StreamSynthesisRequest(synthesis_input=tts_pb2.SynthesisInput(text=item))
+
+    async def __aenter__(self) -> YandexRealtimeSession:
+        await self.open()
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        await self.flush_and_close()
+
+
+def _audio_spec(tts_pb2: Any) -> Any:
+    """AudioFormatOptions for raw 16 kHz mono LINEAR16 PCM (anam-native)."""
+    return tts_pb2.AudioFormatOptions(
+        raw_audio=tts_pb2.RawAudio(
+            audio_encoding=tts_pb2.RawAudio.LINEAR16_PCM,
+            sample_rate_hertz=_SAMPLE_RATE,
+        )
+    )

--- a/assemblix-app-api/assemblix_api/nodes/agent_voice.py
+++ b/assemblix-app-api/assemblix_api/nodes/agent_voice.py
@@ -13,7 +13,10 @@ from uuid import UUID
 
 from assemblix_api.core.settings import get_settings
 from assemblix_api.external.voice.pricing import compute_tts_cost
-from assemblix_api.external.voice.realtime import RealtimeTTSSession
+from assemblix_api.external.voice.realtime_dispatch import (
+    RealtimeSession,
+    create_realtime_session,
+)
 from assemblix_api.external.voice.synthesis import synthesize
 from assemblix_api.external.voice.voice_catalog import has_realtime_route
 from assemblix_api.schemas.execution import ExecutionContext
@@ -59,11 +62,12 @@ async def open_voice_session(
     *,
     on_delta: OnDelta,
     on_audio: OnAudio,
-) -> tuple[RealtimeTTSSession, OnDelta, bool]:
-    """Open a live WS session; return (session, tee_on_delta, is_system_key)."""
+) -> tuple[RealtimeSession, OnDelta, bool]:
+    """Open a live streaming session; return (session, tee_on_delta, is_system_key)."""
     assert cfg.voice is not None
     api_key, is_system_key = await _resolve_key(cfg, context)
-    session = RealtimeTTSSession(
+    session = create_realtime_session(
+        provider=cfg.voice.provider,
         api_key=api_key,
         voice_id=cfg.voice.voice_id,  # type: ignore[arg-type]
         model=cfg.voice.model,

--- a/assemblix-app-api/pyproject.toml
+++ b/assemblix-app-api/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "prometheus-fastapi-instrumentator>=7.1.0",
     "websockets>=15.0.1",
     "av>=18.0.0",
+    "yandexcloud>=0.401.0",
 ]
 
 [project.optional-dependencies]

--- a/assemblix-app-api/tests/integration/test_streaming_voice_e2e.py
+++ b/assemblix-app-api/tests/integration/test_streaming_voice_e2e.py
@@ -91,7 +91,7 @@ async def test_streaming_voice_emits_audio_before_agent_step_complete(
     mock_llm.set_stream(["Hi ", "there."])
     mock_tts_ws.script_audio([(b"\x01\x02", None), (b"\x03\x04", None)])
     mocker.patch(
-        "assemblix_api.nodes.agent_voice.RealtimeTTSSession",
+        "assemblix_api.external.voice.realtime_dispatch.RealtimeTTSSession",
         lambda **kw: RealtimeTTSSession(**{**kw, "connect": mock_tts_ws.connect}),
     )
     setup = await _setup(api_client)
@@ -136,7 +136,9 @@ async def test_non_stream_voice_has_no_audio_delta(
 
     monkeypatch.setattr(get_settings(), "system_elevenlabs_api_key", "xi-system")
     mock_llm.set_response("Hi there.")
-    ws = mocker.patch("assemblix_api.nodes.agent_voice.RealtimeTTSSession")
+    ws = mocker.patch(
+        "assemblix_api.external.voice.realtime_dispatch.RealtimeTTSSession"
+    )
     setup = await _setup(api_client)
 
     # Act

--- a/assemblix-app-api/tests/integration/test_streaming_voice_e2e.py
+++ b/assemblix-app-api/tests/integration/test_streaming_voice_e2e.py
@@ -136,9 +136,7 @@ async def test_non_stream_voice_has_no_audio_delta(
 
     monkeypatch.setattr(get_settings(), "system_elevenlabs_api_key", "xi-system")
     mock_llm.set_response("Hi there.")
-    ws = mocker.patch(
-        "assemblix_api.external.voice.realtime_dispatch.RealtimeTTSSession"
-    )
+    ws = mocker.patch("assemblix_api.external.voice.realtime_dispatch.RealtimeTTSSession")
     setup = await _setup(api_client)
 
     # Act

--- a/assemblix-app-api/tests/unit/nodes/test_agent_node_voice_execute.py
+++ b/assemblix-app-api/tests/unit/nodes/test_agent_node_voice_execute.py
@@ -55,7 +55,7 @@ async def test_live_voice_tees_and_meters(mock_llm, mock_tts_ws, mocker):
     mock_llm.set_stream(["Hello ", "world."])
     mock_tts_ws.script_audio([(b"\x01", None)])
     mocker.patch(
-        "assemblix_api.nodes.agent_voice.RealtimeTTSSession",
+        "assemblix_api.external.voice.realtime_dispatch.RealtimeTTSSession",
         lambda **kw: RealtimeTTSSession(**{**kw, "connect": mock_tts_ws.connect}),
     )
     context = make_context(

--- a/assemblix-app-api/tests/unit/test_yandex_realtime.py
+++ b/assemblix-app-api/tests/unit/test_yandex_realtime.py
@@ -1,0 +1,68 @@
+"""Happy-flow coverage for the Yandex SpeechKit v3 realtime TTS provider.
+
+Uses an injected fake gRPC stub (no network): feed two sentences, assert both are
+synthesized whole and their PCM is forwarded to ``on_audio`` in order.
+"""
+
+import pytest
+from yandex.cloud.ai.tts.v3 import tts_pb2
+
+from assemblix_api.external.voice.yandex_realtime import YandexRealtimeSession
+
+
+class _FakeCall:
+    """Async-iterable UnaryStream call returning two PCM chunks."""
+
+    def __init__(self):
+        self._chunks = [b"\x01\x02", b"\x03\x04"]
+
+    async def __aiter__(self):
+        for data in self._chunks:
+            yield tts_pb2.UtteranceSynthesisResponse(audio_chunk=tts_pb2.AudioChunk(data=data))
+
+
+class _FakeStub:
+    def __init__(self):
+        self.calls = []
+
+    def UtteranceSynthesis(self, request, metadata=None):
+        self.calls.append((request, metadata))
+        return _FakeCall()
+
+
+@pytest.mark.asyncio
+async def test_yandex_realtime_utterance_happy_flow():
+    # Arrange
+    received: list[bytes] = []
+
+    async def on_audio(pcm, _alignment):
+        received.append(pcm)
+
+    stub = _FakeStub()
+    session = YandexRealtimeSession(
+        credential="b1folder:AQVN-key",
+        voice_id="alena",
+        model="yandex-tts-v3",
+        on_audio=on_audio,
+        mode="utterance",
+        stub=stub,
+    )
+
+    # Act
+    await session.open()
+    await session.send_text("Привет. ")
+    await session.send_text("Как дела?")
+    chars = await session.flush_and_close()
+
+    # Assert — both sentences synthesized whole, PCM forwarded in order.
+    assert chars == len("Привет. ") + len("Как дела?")
+    assert [req.text for req, _ in stub.calls] == ["Привет.", "Как дела?"]
+    assert received == [b"\x01\x02", b"\x03\x04", b"\x01\x02", b"\x03\x04"]
+
+    # Request shape: raw 16 kHz LINEAR16 PCM, voice hint, Api-Key + folder metadata.
+    req, meta = stub.calls[0]
+    assert req.output_audio_spec.raw_audio.audio_encoding == tts_pb2.RawAudio.LINEAR16_PCM
+    assert req.output_audio_spec.raw_audio.sample_rate_hertz == 16000
+    assert req.hints[0].voice == "alena"
+    assert ("authorization", "Api-Key AQVN-key") in meta
+    assert ("x-folder-id", "b1folder") in meta

--- a/assemblix-app-api/uv.lock
+++ b/assemblix-app-api/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "assemblix-api"
-version = "0.2.8"
+version = "0.2.23"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
@@ -258,6 +258,7 @@ dependencies = [
     { name = "tenacity" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
+    { name = "yandexcloud" },
 ]
 
 [package.optional-dependencies]
@@ -314,6 +315,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.1.2" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
     { name = "websockets", specifier = ">=15.0.1" },
+    { name = "yandexcloud", specifier = ">=0.401.0" },
 ]
 provides-extras = ["dev"]
 
@@ -829,6 +831,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/6e/1c8331ddf91ca4730ab3086a0f1be19c65510a33b5a441cb334e7a2d2560/cryptography-46.0.3-cp38-abi3-win32.whl", hash = "sha256:6276eb85ef938dc035d59b87c8a7dc559a232f954962520137529d77b18ff1df", size = 3036695, upload-time = "2025-10-15T23:18:08.672Z" },
     { url = "https://files.pythonhosted.org/packages/90/45/b0d691df20633eff80955a0fc7695ff9051ffce8b69741444bd9ed7bd0db/cryptography-46.0.3-cp38-abi3-win_amd64.whl", hash = "sha256:416260257577718c05135c55958b674000baef9a1c7d9e8f306ec60d71db850f", size = 3501720, upload-time = "2025-10-15T23:18:10.632Z" },
     { url = "https://files.pythonhosted.org/packages/e8/cb/2da4cc83f5edb9c3257d09e1e7ab7b23f049c7962cae8d842bbef0a9cec9/cryptography-46.0.3-cp38-abi3-win_arm64.whl", hash = "sha256:d89c3468de4cdc4f08a57e214384d0471911a3830fcdaf7a8cc587e42a866372", size = 2918740, upload-time = "2025-10-15T23:18:12.277Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
 ]
 
 [[package]]
@@ -1368,6 +1382,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1409,33 +1435,66 @@ wheels = [
 
 [[package]]
 name = "grpcio"
-version = "1.76.0"
+version = "1.83.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/e0/318c1ce3ae5a17894d5791e87aea147587c9e702f24122cc7a5c8bbaeeb1/grpcio-1.76.0.tar.gz", hash = "sha256:7be78388d6da1a25c0d5ec506523db58b18be22d9c37d8d3a32c08be4987bd73", size = 12785182, upload-time = "2025-10-21T16:23:12.106Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/304898ac4e04e2d5e4e4c2eadc178b1f2a16d5f4bc2f91306c87d64680b9/grpcio-1.83.0.tar.gz", hash = "sha256:7674587248fbbb2ac6e4eecf83a8a0f3d91a928f941de571acfd3a2f007fbc24", size = 13428824, upload-time = "2026-07-23T15:20:37.759Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/ed/71467ab770effc9e8cef5f2e7388beb2be26ed642d567697bb103a790c72/grpcio-1.76.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:26ef06c73eb53267c2b319f43e6634c7556ea37672029241a056629af27c10e2", size = 5807716, upload-time = "2025-10-21T16:21:48.475Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/85/c6ed56f9817fab03fa8a111ca91469941fb514e3e3ce6d793cb8f1e1347b/grpcio-1.76.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:45e0111e73f43f735d70786557dc38141185072d7ff8dc1829d6a77ac1471468", size = 11821522, upload-time = "2025-10-21T16:21:51.142Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/31/2b8a235ab40c39cbc141ef647f8a6eb7b0028f023015a4842933bc0d6831/grpcio-1.76.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83d57312a58dcfe2a3a0f9d1389b299438909a02db60e2f2ea2ae2d8034909d3", size = 6362558, upload-time = "2025-10-21T16:21:54.213Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/64/9784eab483358e08847498ee56faf8ff6ea8e0a4592568d9f68edc97e9e9/grpcio-1.76.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3e2a27c89eb9ac3d81ec8835e12414d73536c6e620355d65102503064a4ed6eb", size = 7049990, upload-time = "2025-10-21T16:21:56.476Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/94/8c12319a6369434e7a184b987e8e9f3b49a114c489b8315f029e24de4837/grpcio-1.76.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61f69297cba3950a524f61c7c8ee12e55c486cb5f7db47ff9dcee33da6f0d3ae", size = 6575387, upload-time = "2025-10-21T16:21:59.051Z" },
-    { url = "https://files.pythonhosted.org/packages/15/0f/f12c32b03f731f4a6242f771f63039df182c8b8e2cf8075b245b409259d4/grpcio-1.76.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a15c17af8839b6801d554263c546c69c4d7718ad4321e3166175b37eaacca77", size = 7166668, upload-time = "2025-10-21T16:22:02.049Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/2d/3ec9ce0c2b1d92dd59d1c3264aaec9f0f7c817d6e8ac683b97198a36ed5a/grpcio-1.76.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:25a18e9810fbc7e7f03ec2516addc116a957f8cbb8cbc95ccc80faa072743d03", size = 8124928, upload-time = "2025-10-21T16:22:04.984Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/74/fd3317be5672f4856bcdd1a9e7b5e17554692d3db9a3b273879dc02d657d/grpcio-1.76.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:931091142fd8cc14edccc0845a79248bc155425eee9a98b2db2ea4f00a235a42", size = 7589983, upload-time = "2025-10-21T16:22:07.881Z" },
-    { url = "https://files.pythonhosted.org/packages/45/bb/ca038cf420f405971f19821c8c15bcbc875505f6ffadafe9ffd77871dc4c/grpcio-1.76.0-cp313-cp313-win32.whl", hash = "sha256:5e8571632780e08526f118f74170ad8d50fb0a48c23a746bef2a6ebade3abd6f", size = 3984727, upload-time = "2025-10-21T16:22:10.032Z" },
-    { url = "https://files.pythonhosted.org/packages/41/80/84087dc56437ced7cdd4b13d7875e7439a52a261e3ab4e06488ba6173b0a/grpcio-1.76.0-cp313-cp313-win_amd64.whl", hash = "sha256:f9f7bd5faab55f47231ad8dba7787866b69f5e93bc306e3915606779bbfb4ba8", size = 4702799, upload-time = "2025-10-21T16:22:12.709Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/46/39adac80de49d678e6e073b70204091e76631e03e94928b9ea4ecf0f6e0e/grpcio-1.76.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:ff8a59ea85a1f2191a0ffcc61298c571bc566332f82e5f5be1b83c9d8e668a62", size = 5808417, upload-time = "2025-10-21T16:22:15.02Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/f5/a4531f7fb8b4e2a60b94e39d5d924469b7a6988176b3422487be61fe2998/grpcio-1.76.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:06c3d6b076e7b593905d04fdba6a0525711b3466f43b3400266f04ff735de0cd", size = 11828219, upload-time = "2025-10-21T16:22:17.954Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/1c/de55d868ed7a8bd6acc6b1d6ddc4aa36d07a9f31d33c912c804adb1b971b/grpcio-1.76.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd5ef5932f6475c436c4a55e4336ebbe47bd3272be04964a03d316bbf4afbcbc", size = 6367826, upload-time = "2025-10-21T16:22:20.721Z" },
-    { url = "https://files.pythonhosted.org/packages/59/64/99e44c02b5adb0ad13ab3adc89cb33cb54bfa90c74770f2607eea629b86f/grpcio-1.76.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b331680e46239e090f5b3cead313cc772f6caa7d0fc8de349337563125361a4a", size = 7049550, upload-time = "2025-10-21T16:22:23.637Z" },
-    { url = "https://files.pythonhosted.org/packages/43/28/40a5be3f9a86949b83e7d6a2ad6011d993cbe9b6bd27bea881f61c7788b6/grpcio-1.76.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2229ae655ec4e8999599469559e97630185fdd53ae1e8997d147b7c9b2b72cba", size = 6575564, upload-time = "2025-10-21T16:22:26.016Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/a9/1be18e6055b64467440208a8559afac243c66a8b904213af6f392dc2212f/grpcio-1.76.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:490fa6d203992c47c7b9e4a9d39003a0c2bcc1c9aa3c058730884bbbb0ee9f09", size = 7176236, upload-time = "2025-10-21T16:22:28.362Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/55/dba05d3fcc151ce6e81327541d2cc8394f442f6b350fead67401661bf041/grpcio-1.76.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:479496325ce554792dba6548fae3df31a72cef7bad71ca2e12b0e58f9b336bfc", size = 8125795, upload-time = "2025-10-21T16:22:31.075Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/45/122df922d05655f63930cf42c9e3f72ba20aadb26c100ee105cad4ce4257/grpcio-1.76.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1c9b93f79f48b03ada57ea24725d83a30284a012ec27eab2cf7e50a550cbbbcc", size = 7592214, upload-time = "2025-10-21T16:22:33.831Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/6e/0b899b7f6b66e5af39e377055fb4a6675c9ee28431df5708139df2e93233/grpcio-1.76.0-cp314-cp314-win32.whl", hash = "sha256:747fa73efa9b8b1488a95d0ba1039c8e2dca0f741612d80415b1e1c560febf4e", size = 4062961, upload-time = "2025-10-21T16:22:36.468Z" },
-    { url = "https://files.pythonhosted.org/packages/19/41/0b430b01a2eb38ee887f88c1f07644a1df8e289353b78e82b37ef988fb64/grpcio-1.76.0-cp314-cp314-win_amd64.whl", hash = "sha256:922fa70ba549fce362d2e2871ab542082d66e2aaf0c19480ea453905b01f384e", size = 4834462, upload-time = "2025-10-21T16:22:39.772Z" },
+    { url = "https://files.pythonhosted.org/packages/56/eb/135daaa713f32d33b8f99b4153b3f8dc3b2a124996ac15581bf9ebdad3c3/grpcio-1.83.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:6662f3b1e07cc7493d437351860dc867bddc6a93c83ecf33bbfdaf0c217ab2d0", size = 6304480, upload-time = "2026-07-23T15:19:53.962Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a1/121806ce69f23138dabe06aa595b0e5f1ae051a37e4c1954eed7d692c800/grpcio-1.83.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:74fe6f9e8a35c7dbf32255ee154d15e3e5338a81ed39173d079d594d2e544cd1", size = 12154419, upload-time = "2026-07-23T15:19:56.3Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/e8/d0389e09cd6b4c4d3089b92967ae4e3ffd64795bd349bf2f85cd6656d3da/grpcio-1.83.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10b3fa0475eb572c9a81a6fe37fa16a9c500c0c91cfc148cac15692b7e3c2867", size = 6873200, upload-time = "2026-07-23T15:19:58.701Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/51/f464c1d211fa50d5adbabe1b2e519948d99c13757052bfc9ea7afa28e284/grpcio-1.83.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5f20a988480b0f28207f057f7f7ae1313393c3cef0adcfeae8248f9947eaf881", size = 7618811, upload-time = "2026-07-23T15:20:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c0/539fe0832f2dd6500a28f5263071623fb34e8d4867aec632ccf81bd21156/grpcio-1.83.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7bd82671b39065ba18cd536e9cd45b27ff649053f81ddd2c6a966d595067080f", size = 7042310, upload-time = "2026-07-23T15:20:02.675Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ca/ccf617d37ffa72567fa8e005ec7090c99da922799be2fb9847c8b21ca18c/grpcio-1.83.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc60215b5cb9fc8ca72942c498b551ac2305bd08f6ef8d4e3f0d21b64fbecd61", size = 7575412, upload-time = "2026-07-23T15:20:04.712Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b9/fd8d5245f823a8e0fd35d90e20ea3aa4acd47f8d5318fa8df307df52dec6/grpcio-1.83.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f1c3e5689d4b90987b1d72022bcfe866a9a3dc66197484cf856d96b6150e7f45", size = 8604248, upload-time = "2026-07-23T15:20:06.77Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1e/f37632fc11db72dfa4bba86c3a43e54358e53030df111ecae5e91a733ad6/grpcio-1.83.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a21cb4eeeba124443f399be2e8b624943cde864dcbe588cb42e5c483a52a906c", size = 7977458, upload-time = "2026-07-23T15:20:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b6/d70b69ae5c0cfc341b9ba474980e4ed99cbf05c0e4a14e9eee8cb73db0a5/grpcio-1.83.0-cp313-cp313-win32.whl", hash = "sha256:8fe04f1050a59f875601eb55d42b4f66946fe89817f967e34db1462ccd07dadf", size = 4393993, upload-time = "2026-07-23T15:20:11.017Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/13/45d4cccb555cf4c476226979bf3d2fd0b0254216f7564c3a053e35117efc/grpcio-1.83.0-cp313-cp313-win_amd64.whl", hash = "sha256:6e01ecd9d8ef280abe1365138a4dc318f9a5287f4cb1b41d07816f796653f735", size = 5159650, upload-time = "2026-07-23T15:20:12.979Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/60/f2cca8147ea213d3e43ae9158d03ad04e020fdf32ff027253e1fe93f921d/grpcio-1.83.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3f351629f6ae16ecc0ec3553e586a6763ffd9f6114044286d0cbec3e09241bfa", size = 6305607, upload-time = "2026-07-23T15:20:15.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ab/d3874931d123a95e83a3ebf8aa04537988fb62425cedb8bf3cefc5ad41b2/grpcio-1.83.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d05ff664100d429335b93c91b8b34ddf9e94a112205e7fa06dede309e44a4e4c", size = 12166617, upload-time = "2026-07-23T15:20:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ff/6f18f9426b69306f4e00a9add3b0ee2748da8aad53836ef80cab0d62d04f/grpcio-1.83.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7936f2a56cf04f6514705c0fedf400971de01b6aa1719327e4718f410a765e2b", size = 6880213, upload-time = "2026-07-23T15:20:19.98Z" },
+    { url = "https://files.pythonhosted.org/packages/70/21/706d1147c6b93b98f179240c13991fbcc56880eba0c868abb1ad40d8a0a6/grpcio-1.83.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b0a0be840e51b6b7ee9df9269770faf77bdf4b771053c257c21d12bad607714c", size = 7618335, upload-time = "2026-07-23T15:20:22.161Z" },
+    { url = "https://files.pythonhosted.org/packages/74/04/1a8443c889115ec9e213a213e86bc93a71ee9088027e5befa09aaa0edd9d/grpcio-1.83.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:009667eaf3dcd5224c713589cdc98e7ca4ed0ff0b61132c6b276e930eb83a2df", size = 7043416, upload-time = "2026-07-23T15:20:24.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c6/94e0fee5b12bc1da1370185b680988db6f739d19b42d9959db01a7ea50bf/grpcio-1.83.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bb669918fd88936b15599caff4160a77ab74bdeb25f2231f6e45b61282d6107b", size = 7583253, upload-time = "2026-07-23T15:20:26.313Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/97/de1ccb671fb85575bc5192faedf9ecdbdf5b390d2e6584dcf552bcbd370e/grpcio-1.83.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:c19b454d3d3f28db81f2c7c4dbaee96e7f6fd149721733ffe79d6bc530f17404", size = 8605102, upload-time = "2026-07-23T15:20:28.437Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0f/0e0ec749a7034ffcbaa050e39779872950ead90c22e7e0116be3f28b2b46/grpcio-1.83.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:61007cd08640abc5c54547ee32505474c482cd733a53cb87551ea81faa6350af", size = 7979826, upload-time = "2026-07-23T15:20:31.182Z" },
+    { url = "https://files.pythonhosted.org/packages/83/fa/c3fda157287f64bc65acee6c5aa90c41acf9e0d3a8e69a265eecff6d00a1/grpcio-1.83.0-cp314-cp314-win32.whl", hash = "sha256:32e11c37f5285b0c6fa3042c05fe06903696689749833fc64e67dec71b9bbe33", size = 4471765, upload-time = "2026-07-23T15:20:33.195Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/00/b1b26431c9d54eee11724fd6e5585473a2ed47fbc1fb95e5204906a642ce/grpcio-1.83.0-cp314-cp314-win_amd64.whl", hash = "sha256:2bb48cb5e6dd005ca12b89ce4b6ac0b48ff3112c747542ee7986ef611a8ca6d9", size = 5298932, upload-time = "2026-07-23T15:20:35.48Z" },
+]
+
+[[package]]
+name = "grpcio-tools"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "protobuf" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/b3/1c5951352d6777fd7f99a0ccee04617fdfd8a5dbf2918a1f58c8b2b280b8/grpcio_tools-1.81.1.tar.gz", hash = "sha256:a22a3870180927fdd84e2b27d079ef5b7f5f8c6110181b6736afc17a463481f1", size = 6236155, upload-time = "2026-06-11T12:51:21.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/90/5faa8b26e03495e5117f93bef8293cbada4af136362745dad7d1813ef0b0/grpcio_tools-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:3d604b4fd114b79ebb9f865bf3e04fd3ae93c704e1fad96f7fd03b0865c263b7", size = 2586071, upload-time = "2026-06-11T12:50:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/9a/85dc589fa6ae2439451eaa81a1578de31e29c676980d38bef7549b8a1f45/grpcio_tools-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:3389e705460efa3f3758141ba5520e6743b131c9576197c944fb9cbe49048126", size = 5813299, upload-time = "2026-06-11T12:50:31.295Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fd/c53994e58a837e6eefe48f53eb3492afc04f2b8af255df4adb37d14378f8/grpcio_tools-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8a17d8ceeb6a855fadf39f5171c80a382d97c4db98d5943eca553497fdebf84b", size = 2634668, upload-time = "2026-06-11T12:50:33.938Z" },
+    { url = "https://files.pythonhosted.org/packages/34/32/de988e86688686a2117e7ce6ce9eff4f638c929bb55b0afe60d6fbd2e45c/grpcio_tools-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:43baf71dc60fd653062da2e95e95c73b35dd130be8f9fa3d544c3af3f808a290", size = 2957930, upload-time = "2026-06-11T12:50:36.726Z" },
+    { url = "https://files.pythonhosted.org/packages/72/97/3f18a0ea32b5f809d21961dbd0bc382b589a4c3d501e3d67c345d5456ed3/grpcio_tools-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:136e90906af0df51ad929713244ba812d0dbb1844b4f467d5d86bdb054698f90", size = 2697760, upload-time = "2026-06-11T12:50:39.108Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c0/dbf5cbc877290ff7504a59959a8af4fdcfdaa1e84237948405ccf1aa82a6/grpcio_tools-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd6c3bf3ea6a61eb58c54368d72ada591f2a270f3a31a32e8536e773337e76d9", size = 3151456, upload-time = "2026-06-11T12:50:41.983Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ea/16fe2dc83140a59e5c0a0b9dc2693dd36bfaa6bd835724b4ec66a68eab7b/grpcio_tools-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c306c307f8f74cddc4056fdbb6f1da55de087a21120efbd02bd915daa5a52fd", size = 3710469, upload-time = "2026-06-11T12:50:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7d/df987d7d81e7ad2f7516d9e9d56ff29c54dbc6d8587e425688dca9a28e49/grpcio_tools-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bdbdc927be2e0ea13c32564a72ee31d712a716fb6f8c0d53d37a77d8277c272c", size = 3370488, upload-time = "2026-06-11T12:50:47.199Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c5/5a63444d694ea47bf670138208f71830cc1759c402c8818092b28ab2dc5f/grpcio_tools-1.81.1-cp313-cp313-win32.whl", hash = "sha256:9d383724bcd67244b6def9e9164c640ee9380c0b7534ee7545a6fb0022a59afe", size = 1008229, upload-time = "2026-06-11T12:50:49.527Z" },
+    { url = "https://files.pythonhosted.org/packages/00/75/3945e26d5c94ae6ed9be5caef73d4d66c47dc8cfdd7b4995efaf942754e0/grpcio_tools-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:f3eb15849979ca7bb864ce81a74d68b0f225a7f111ed3fe212bfc08cf9812b10", size = 1174523, upload-time = "2026-06-11T12:50:51.755Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/08/e581ad42ae517a61172285047e4d710e2ac75f2f1915f7c91f284254e6d5/grpcio_tools-1.81.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:7d168ea26390717d0462c0d0408331dc98a60fc7f7e6118afac9b73f5a66d87c", size = 2585944, upload-time = "2026-06-11T12:50:54.528Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c8/200d90ebad685af7eea5ff7e0360c504dd01ec053fe0f1f9c4abe3ea2d5a/grpcio_tools-1.81.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:43c528655b226375013036692d8db4cd59060c1f41dd62c77f4d17b69f6ce828", size = 5813492, upload-time = "2026-06-11T12:50:57.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c0/60da2a1af37aa8eb47308cec24d9f7709a8976fdec3a53fd35b56b358326/grpcio_tools-1.81.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a9c6fcc68c9d5a208967bfe4fd3224d3c3be9a950c3e827e8f4b17e15c2dc555", size = 2634991, upload-time = "2026-06-11T12:50:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/7f/dede28b579ae9bf9079ba1aa913e8088d1dc0cdbe21c85caa22f0790cad2/grpcio_tools-1.81.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:a987c85dcbe1b32066d7acd46266d1a428aecbd629331bf5b853e74c835bf876", size = 2957913, upload-time = "2026-06-11T12:51:02.31Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/38/4de2118adb58ec7ffba65ec623b5836db769665c192517cbf187db3f6145/grpcio_tools-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a882382507bb5ec6d7edc9648053dfd3bc8f9285cde56a6fa9b9a83b4bd07f1c", size = 2697709, upload-time = "2026-06-11T12:51:05.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e1/762ced51059e4f694fd337ecae491581d42a4e61dcb0415d8c5c60e6ddcb/grpcio_tools-1.81.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7746e508d4239a02f7e93638be5bc0ebb0120ddb796f7506aaae9d47a4599d97", size = 3151884, upload-time = "2026-06-11T12:51:07.593Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/9823090dc801e7229944874e7429c3b98e741ac778d8dc373f60240e1c43/grpcio_tools-1.81.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:fc3d2a41a7a4467fa03b391394fffada9291fe8feebc8679b526f6bc36942b25", size = 3710404, upload-time = "2026-06-11T12:51:10.172Z" },
+    { url = "https://files.pythonhosted.org/packages/64/4e/4eae98d02148cb6f9f452f09942afba407afa6851e6c1fddc5ae9ec0b4ed/grpcio_tools-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:21bb3ba90e6d8df1ff663d4ee39a4e5b25a64e8ed4902476ca9ded0954d3917a", size = 3370525, upload-time = "2026-06-11T12:51:12.678Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/3e/2206e597a128da6a03a6106d2eaf2c3e72c7d80843d4be933e3a3d10d02a/grpcio_tools-1.81.1-cp314-cp314-win32.whl", hash = "sha256:3dca56016d90a710c4d9861bae793dc089c1430a90c79ce672e948ddb65fa539", size = 1030582, upload-time = "2026-06-11T12:51:14.906Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f2/bbeef86c687225b7bbc7c0acdfbd25c8bcaa3f5b1c941db053e5c3d9e859/grpcio_tools-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:cb08172b7b629e75cb33866928d319a3196540a725eaab628ba721007140f1af", size = 1207490, upload-time = "2026-06-11T12:51:17.598Z" },
 ]
 
 [[package]]
@@ -2537,6 +2596,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
 name = "psutil"
 version = "7.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3392,6 +3466,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3891,6 +3974,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
+]
+
+[[package]]
+name = "yandexcloud"
+version = "0.401.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "deprecated" },
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "grpcio-tools" },
+    { name = "protobuf" },
+    { name = "pyjwt" },
+    { name = "requests" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/7b/3f638dd07e82a77fdf84a38095bfdcc88295da2ad850b23cc6e5a8520151/yandexcloud-0.401.0.tar.gz", hash = "sha256:14c4c76e2999d6b35c3d5ace9081cecfa60f83d80bef68cd58845b59e921b99b", size = 4128639, upload-time = "2026-07-27T16:59:35.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/34/8037e9dc76b60b8503456b53c9b9c96895dacf0b3e602230a3b4a86a190f/yandexcloud-0.401.0-py3-none-any.whl", hash = "sha256:ef43714a24a484f87c961e97995c86d8ab714a642cf3570ef172b131216687d0", size = 6361354, upload-time = "2026-07-27T16:59:33.45Z" },
 ]
 
 [[package]]

--- a/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/node-forms/voice-output-picker.tsx
+++ b/assemblix-app-web/src/entities/workflow/lib/workflow-editor/ui/node-forms/voice-output-picker.tsx
@@ -137,15 +137,21 @@ export const VoiceOutputPicker = ({
       : true
     : false;
 
-  const usingSystemKey =
-    Boolean(provider) && !value?.credentialId && hasVoiceSystemKey;
+  // Fetch the provider's voices whenever no personal credential is chosen. For
+  // key-listed providers (ElevenLabs) this needs a system key and 503s without
+  // one; for static-catalog providers (Yandex) it always returns the catalog.
+  // Availability is therefore driven by what actually comes back — not by the
+  // system-key config flag, which flips to false once serverConfig loads and
+  // would otherwise unmount a picker whose voices already arrived.
+  const systemVoicesEnabled = Boolean(provider) && !value?.credentialId;
+  const usingSystemKey = systemVoicesEnabled && hasVoiceSystemKey;
   const { data: systemVoices = [], isLoading: isLoadingSystemVoices } =
     useGetSystemVoicesQuery(
       {
         providerName: provider ?? "",
         search: debouncedVoiceSearch.trim() || undefined,
       },
-      { skip: !usingSystemKey },
+      { skip: !systemVoicesEnabled },
     );
   const availableVoices = value?.credentialId ? credentialVoices : systemVoices;
   const isLoadingVoices = value?.credentialId
@@ -233,7 +239,10 @@ export const VoiceOutputPicker = ({
         </Select>
       </div>
 
-      {provider && (value?.credentialId || usingSystemKey) && (
+      {provider &&
+        (value?.credentialId ||
+          usingSystemKey ||
+          availableVoices.length > 0) && (
         <div className="space-y-2">
           <Label className="text-xs">{t("nodeForms.end.voice")}</Label>
           <Select


### PR DESCRIPTION
## Why

ElevenLabs handles Russian poorly in realtime (choppy prosody on the anam avatar's lip-sync). Yandex SpeechKit is natively Russian-first and sounds noticeably more natural. This adds it as a **streaming TTS provider** for the avatar / realtime-voice path — alongside ElevenLabs, without breaking it.

## What's inside

**Backend**
- `external/voice/yandex_realtime.py` — gRPC v3 session with the same duck-typed contract as ElevenLabs (`open / send_text / flush_and_close` + `on_audio`). **Two modes**, selected by model id:
  - `utterance` (`UtteranceSynthesis`, server-streaming) — buffers deltas and synthesizes **whole sentences** for the best Russian prosody; audio still streams out per sentence.
  - `stream` (`StreamSynthesis`, bidirectional) — lowest time-to-first-audio.
  - Emits `LINEAR16_PCM @ 16 kHz mono` — exactly what anam passthrough expects, no resampling.
  - Best-effort: a gRPC error stops audio but never raises into the caller's text stream.
- `external/voice/realtime_dispatch.py` — provider seam (sibling of `synthesis.py`) that picks the session class; `agent_voice.open_voice_session` now goes through it (was ElevenLabs-hardcoded).
- `models/yandex.json` — two realtime models. **The model picker doubles as the mode switch** — no new config field, no agent-form changes.
- New `YANDEX_TTS_V3_GRPC_ENDPOINT` setting (default `tts.api.cloud.yandex.net:443`), plus the `yandexcloud` dependency.

**Frontend**
- Fix: Yandex voices are a static, keyless catalog, but the picker's visibility was gated on `serverConfig.systemApiKeys[provider]`, which is `false` without a system key. While serverConfig loaded, the flag was optimistically `true` (firing the fetch), then flipped `false` — unmounting a picker whose voices had already arrived. Now the picker shows whenever voices actually come back; no provider-name hardcoding. ElevenLabs without a key still 503s (picker stays hidden).

## Tests / gates
- `tests/unit/test_yandex_realtime.py` — happy-flow (two sentences synthesized whole, PCM forwarded in order, correct request shape: PCM/16k, voice hint, `Api-Key` + `x-folder-id`).
- Retargeted the existing realtime-session mocks to the new dispatch seam.
- ruff / mypy / `tsc` / eslint green; no regressions in neighboring voice tests.

## ⚠️ After merge
A new `yandexcloud` dependency was added → **rebuild the api and worker images** (`docker compose … up -d --build api worker`), otherwise you'll hit `ModuleNotFoundError: No module named 'yandex'` at runtime.

## How to use
Yandex credential in the existing `"<folderId>:<apiKey>"` form (type `YANDEX_SPEECHKIT_TOKEN`), or the system `SYSTEM_YANDEX_SPEECHKIT_API_KEY` + `SYSTEM_YANDEX_SPEECHKIT_FOLDER_ID`. In the agent node: provider *Yandex SpeechKit*, pick one of the v3 realtime models, enable realtime, choose a voice, `output_type = avatar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)