### PR TITLE
feat(voice-agents): make the call a public API

### DIFF
--- a/assemblix-app-api/assemblix_api/api/rest/voice_agents.py
+++ b/assemblix-app-api/assemblix_api/api/rest/voice_agents.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, status
 
+from assemblix_api.api.rest._scope import resolve_project_id
 from assemblix_api.core.auth_context import AuthContext
 from assemblix_api.dependencies import (
     get_auth_context,
@@ -25,13 +26,16 @@ router = APIRouter(prefix="/voice-agents", tags=["Voice Agents"])
 
 @router.get("/", response_model=list[VoiceAgentResponse])
 async def list_voice_agents(
-    project_id: UUID = Query(..., description="Project ID"),
+    project_id: UUID | None = Query(
+        None, description="Project ID; omit when using a project-scoped API key"
+    ),
     auth: AuthContext = Depends(get_auth_context),
     service: VoiceAgentService = Depends(get_voice_agent_service),
     project_service: ProjectService = Depends(get_project_service),
 ):
-    await project_service.authorize_project_access(auth, project_id)
-    return await service.get_project_voice_agents(project_id)
+    effective_project_id = resolve_project_id(project_id, auth)
+    await project_service.authorize_project_access(auth, effective_project_id)
+    return await service.get_project_voice_agents(effective_project_id)
 
 
 @router.get("/{agent_id}", response_model=VoiceAgentResponse)
@@ -53,6 +57,7 @@ async def create_voice_agent(
     service: VoiceAgentService = Depends(get_voice_agent_service),
     project_service: ProjectService = Depends(get_project_service),
 ):
+    data.project_id = resolve_project_id(data.project_id, auth)
     project = await project_service.authorize_project_access(auth, data.project_id)
     return await service.create_voice_agent(project_id=project.id, data=data)
 

--- a/assemblix-app-api/assemblix_api/api/rest/voice_sessions.py
+++ b/assemblix-app-api/assemblix_api/api/rest/voice_sessions.py
@@ -114,6 +114,9 @@ async def create_voice_session(
         token=mint_session_token(
             voice_agent_id=agent.id,
             project_id=agent.project_id,
+            # A project API key means a program is placing this call from someone's
+            # product; a JWT means a person is rehearsing in the editor.
+            is_debug=auth.scoped_project_id is None,
             ttl_seconds=_TOKEN_TTL_SECONDS,
         ),
         expires_in=_TOKEN_TTL_SECONDS,
@@ -146,26 +149,30 @@ class _WebSocketChannel:
 @router.websocket("/sessions/{token}/stream")
 async def stream_voice_session(websocket: WebSocket, token: str) -> None:
     try:
-        voice_agent_id, project_id = verify_session_token(token)
+        scope = verify_session_token(token)
     except InvalidSessionToken:
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return
 
     await websocket.accept()
     try:
-        setup = await load_voice_session_setup(voice_agent_id=voice_agent_id, project_id=project_id)
+        setup = await load_voice_session_setup(
+            voice_agent_id=scope.voice_agent_id, project_id=scope.project_id
+        )
     except HTTPException as exc:
         await websocket.send_json({"type": "session.closed", "reason": exc.detail})
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return
     except Exception:
-        logger.exception("voice_session_setup_failed", voice_agent_id=str(voice_agent_id))
+        logger.exception("voice_session_setup_failed", voice_agent_id=str(scope.voice_agent_id))
         await websocket.send_json({"type": "session.closed", "reason": "setup_failed"})
         await websocket.close(code=status.WS_1011_INTERNAL_ERROR)
         return
 
     voice_session_id = await open_voice_session(
-        voice_agent_id=voice_agent_id, project_id=project_id
+        voice_agent_id=scope.voice_agent_id,
+        project_id=scope.project_id,
+        is_debug=scope.is_debug,
     )
     runtime = VoiceSessionRuntime(
         bridge=create_bridge(provider=setup.provider, api_key=setup.api_key, model=setup.model),
@@ -187,9 +194,9 @@ async def stream_voice_session(websocket: WebSocket, token: str) -> None:
         end_reason = await runtime.run()
     except WebSocketDisconnect:
         end_reason = "user_hangup"
-        logger.info("voice_session_client_gone", voice_agent_id=str(voice_agent_id))
+        logger.info("voice_session_client_gone", voice_agent_id=str(scope.voice_agent_id))
     except Exception:
-        logger.exception("voice_session_failed", voice_agent_id=str(voice_agent_id))
+        logger.exception("voice_session_failed", voice_agent_id=str(scope.voice_agent_id))
     finally:
         input_tokens, output_tokens = runtime.usage
         await close_voice_session(

--- a/assemblix-app-api/assemblix_api/database/models/voice_session.py
+++ b/assemblix-app-api/assemblix_api/database/models/voice_session.py
@@ -57,7 +57,8 @@ class VoiceSession(UUIDMixin, TimestampMixin, Base):
     input_tokens: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     output_tokens: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
 
-    # v1 is editor-test only, so every session is a debug session.
+    # True for a rehearsal in the editor (JWT caller), False for a real call placed
+    # by a program through a project API key.
     is_debug: Mapped[bool] = mapped_column(default=True, nullable=False)
     end_reason: Mapped[str | None] = mapped_column(String(50), default=None)
 

--- a/assemblix-app-api/assemblix_api/dto/requests/voice_agent.py
+++ b/assemblix-app-api/assemblix_api/dto/requests/voice_agent.py
@@ -11,7 +11,10 @@ from assemblix_api.schemas.voice_agent import VoiceAgentConfig
 
 
 class VoiceAgentCreateRequest(DTOModel):
-    project_id: UUID = Field(..., description="ID of the project this voice agent belongs to")
+    project_id: UUID | None = Field(
+        None,
+        description="ID of the project; omit when using a project-scoped API key",
+    )
     name: str = Field(..., min_length=1, max_length=255, description="Voice agent name")
     description: str | None = Field(
         default=None, max_length=1000, description="Optional description"

--- a/assemblix-app-api/assemblix_api/realtime/session_token.py
+++ b/assemblix-app-api/assemblix_api/realtime/session_token.py
@@ -8,6 +8,7 @@ about a minute — long enough to open the socket, useless afterwards.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
@@ -22,21 +23,39 @@ class InvalidSessionToken(Exception):
     """The token is malformed, expired, or not a voice-session token."""
 
 
-def mint_session_token(*, voice_agent_id: UUID, project_id: UUID, ttl_seconds: int = 60) -> str:
+@dataclass(frozen=True)
+class SessionScope:
+    """What one session token authorizes."""
+
+    voice_agent_id: UUID
+    project_id: UUID
+    # A call placed from the editor is a rehearsal; one placed by a program
+    # through a project API key is a real call in someone's product.
+    is_debug: bool
+
+
+def mint_session_token(
+    *,
+    voice_agent_id: UUID,
+    project_id: UUID,
+    is_debug: bool,
+    ttl_seconds: int = 60,
+) -> str:
     settings = get_settings()
     now = datetime.now(UTC)
     payload = {
         "purpose": _PURPOSE,
         "agent": str(voice_agent_id),
         "project": str(project_id),
+        "debug": is_debug,
         "iat": int(now.timestamp()),
         "exp": int((now + timedelta(seconds=ttl_seconds)).timestamp()),
     }
     return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
 
 
-def verify_session_token(token: str) -> tuple[UUID, UUID]:
-    """Return ``(voice_agent_id, project_id)``.
+def verify_session_token(token: str) -> SessionScope:
+    """Return what the token authorizes.
 
     Raises:
         InvalidSessionToken: expired, malformed, or issued for another purpose.
@@ -50,6 +69,10 @@ def verify_session_token(token: str) -> tuple[UUID, UUID]:
     if payload.get("purpose") != _PURPOSE:
         raise InvalidSessionToken("Token was not issued for a voice session")
     try:
-        return UUID(payload["agent"]), UUID(payload["project"])
+        return SessionScope(
+            voice_agent_id=UUID(payload["agent"]),
+            project_id=UUID(payload["project"]),
+            is_debug=bool(payload.get("debug", False)),
+        )
     except (KeyError, ValueError) as exc:
         raise InvalidSessionToken("Token is missing its scope") from exc

--- a/assemblix-app-api/assemblix_api/services/voice_session_service.py
+++ b/assemblix-app-api/assemblix_api/services/voice_session_service.py
@@ -141,7 +141,9 @@ class VoiceSessionService:
             cost_per_minute=(catalog_entry.cost_per_minute or 0.0) if catalog_entry else 0.0,
         )
 
-    async def open_session(self, *, voice_agent_id: UUID, project_id: UUID) -> UUID:
+    async def open_session(
+        self, *, voice_agent_id: UUID, project_id: UUID, is_debug: bool = True
+    ) -> UUID:
         """Create the call's row before any audio flows.
 
         It exists first because the analysis hooks stamp their executions with its
@@ -151,6 +153,7 @@ class VoiceSessionService:
             voice_agent_id=voice_agent_id,
             project_id=project_id,
             status="active",
+            is_debug=is_debug,
         )
         return session.id
 
@@ -254,9 +257,13 @@ async def load_voice_session_setup(*, voice_agent_id: UUID, project_id: UUID) ->
         return await service.build_setup(voice_agent_id=voice_agent_id, project_id=project_id)
 
 
-async def open_voice_session(*, voice_agent_id: UUID, project_id: UUID) -> UUID:
+async def open_voice_session(
+    *, voice_agent_id: UUID, project_id: UUID, is_debug: bool = True
+) -> UUID:
     async with _voice_session_service() as service:
-        return await service.open_session(voice_agent_id=voice_agent_id, project_id=project_id)
+        return await service.open_session(
+            voice_agent_id=voice_agent_id, project_id=project_id, is_debug=is_debug
+        )
 
 
 async def close_voice_session(**kwargs) -> None:

--- a/assemblix-app-web/nginx.conf
+++ b/assemblix-app-web/nginx.conf
@@ -1,6 +1,15 @@
 # nginx config for the production web container.
 # Serves the built SPA and proxies /api to the backend `api` service. Mirrors
 # the dev Vite proxy so `VITE_API_BASE_URL=/api` works identically in both.
+
+# "upgrade" only on requests that actually asked for one; empty (so nginx keeps
+# the connection alive) on every ordinary request. Sending Connection: upgrade
+# unconditionally would break keep-alive for the rest of the API.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      '';
+}
+
 server {
     listen 80;
     server_name _;
@@ -16,11 +25,22 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
+        # WebSocket upgrade, for the voice-agent call
+        # (/api/voice-agents/sessions/{token}/stream). Without HTTP/1.1 and these
+        # two hop-by-hop headers nginx forwards the handshake as a plain request
+        # and the socket never opens — the dev Vite proxy does this for us with
+        # `ws: true`, which is why a call works locally and fails in production.
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
         # Server-Sent Events (debug/execution streams) need buffering off and
-        # long-lived connections.
+        # long-lived connections. A voice call needs the same timeout: it is idle
+        # from nginx's point of view whenever nobody is speaking.
         proxy_buffering off;
         proxy_cache off;
         proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
     }
 
     # Documentation (MkDocs) served by the `docs` container under /docs.

--- a/docs/voice-agents/index.md
+++ b/docs/voice-agents/index.md
@@ -47,7 +47,12 @@ each analysis run links straight into the normal execution viewer.
 Cost is charged by wall-clock time at the model's per-minute price, shown next to the
 model when you pick it.
 
-## Limits in this version
+## Calling the agent from your own product
 
-Voice agents are **test-in-editor only** for now: you call the agent from its page in
-Assemblix. There is no public link, no embeddable widget and no telephony yet.
+The test panel in the editor is not the only way in. The same call is available over a
+public API: your backend mints a short-lived session token with a project API key, your
+frontend opens a WebSocket with it and streams audio. See
+[Integrating a call](integrate.md).
+
+There is no drop-in widget and no telephony yet — you build the client, and the protocol
+is documented so that you can.

--- a/docs/voice-agents/integrate.md
+++ b/docs/voice-agents/integrate.md
@@ -1,0 +1,183 @@
+# Integrating a call
+
+The test panel on the agent page is a client like any other. This page describes the
+protocol it speaks, so you can build your own.
+
+The shape is two steps:
+
+1. **Your backend** mints a short-lived session token with your project API key.
+2. **Your frontend** opens a WebSocket with that token and streams audio both ways.
+
+The key never reaches the browser, and the token is useless a minute after it is issued.
+
+## 1. Mint a session token
+
+```bash
+curl -X POST https://api.assemblix.ai/api/voice-agents/{voiceAgentId}/sessions \
+  -H "Authorization: Bearer sk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+```json
+{ "token": "eyJhbGciOi…", "expiresIn": 60 }
+```
+
+Do this from your server, in response to a request from your own authenticated user —
+the token authorizes exactly one call with one agent, and anyone holding it can place
+that call. Mint it when the user presses the button, not when the page loads: it expires
+in 60 seconds, and that short life is the whole security model.
+
+The agent must be active; an inactive one returns `400`.
+
+## 2. Open the socket
+
+```
+wss://api.assemblix.ai/api/voice-agents/sessions/{token}/stream
+```
+
+No headers, no auth — the token is in the path, which is what makes this work from a
+browser (a WebSocket handshake cannot carry an `Authorization` header).
+
+### What you send
+
+| Frame | Meaning |
+|---|---|
+| **binary** | PCM16 mono, little-endian, at `inputSampleRate` |
+| `{"type": "session.stop"}` | Hang up |
+
+### What you receive
+
+| Frame | Meaning |
+|---|---|
+| `{"type":"session.ready","inputSampleRate":N,"outputSampleRate":N}` | The provider is connected. **Do not send audio before this.** |
+| **binary** | The agent's speech, PCM16 mono at `outputSampleRate` |
+| `{"type":"transcript","role":"user"\|"assistant","text":"…","isFinal":bool}` | Live captions. Non-final frames replace the previous one; final frames are a completed line. |
+| `{"type":"speech.started"}` | The caller cut in. **Drop everything you have queued for playback.** |
+| `{"type":"turn.timings","firstAudioMs":N}` | Last inbound audio → first audio back, for this turn |
+| `{"type":"error","code":…,"message":…,"isFatal":bool}` | A non-fatal error is worth logging and nothing more |
+| `{"type":"session.closed","reason":"…"}` | Terminal. `user_hangup`, `timeout`, `error`, `completed` or `provider_closed`. |
+
+## Sample rates are not a constant
+
+`session.ready` tells you the rates, and they differ by provider: OpenAI Realtime is
+24 kHz in both directions, Gemini Live listens at 16 kHz and answers at 24 kHz. Switching
+an agent's provider changes them under you.
+
+Do not resample. Build the capture graph at `inputSampleRate` and play back at
+`outputSampleRate`, and the browser converts natively:
+
+```js
+const capture = new AudioContext({ sampleRate: inputSampleRate });
+```
+
+This is also why capture must start *after* `session.ready` rather than while the socket
+is opening.
+
+## Barge-in
+
+An `AudioBufferSourceNode` plays to its end once started. Advancing your schedule
+pointer is not enough — on `speech.started` you have to call `stop()` on every source
+already queued, or the agent keeps talking over the caller for however many seconds you
+had buffered. This one detail is the difference between a call that feels alive and one
+that feels like a voicemail system.
+
+## A working client
+
+```js
+async function call(voiceAgentId) {
+  // 1. Your own backend, which holds the project key and mints the token.
+  const { token } = await fetch(`/api/voice-token/${voiceAgentId}`).then(r => r.json());
+
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: { echoCancellation: true, noiseSuppression: true },
+  });
+
+  const socket = new WebSocket(
+    `wss://api.assemblix.ai/api/voice-agents/sessions/${token}/stream`
+  );
+  socket.binaryType = "arraybuffer";
+
+  const playback = new AudioContext();
+  let playAt = 0;
+  const queued = new Set();
+
+  const play = (pcm16, rate) => {
+    const f32 = new Float32Array(pcm16.length);
+    for (let i = 0; i < pcm16.length; i++) f32[i] = pcm16[i] / 32768;
+    const buffer = playback.createBuffer(1, f32.length, rate);
+    buffer.copyToChannel(f32, 0);
+
+    const src = playback.createBufferSource();
+    src.buffer = buffer;
+    src.connect(playback.destination);
+    queued.add(src);
+    src.onended = () => queued.delete(src);
+
+    const startAt = Math.max(playback.currentTime, playAt);
+    src.start(startAt);
+    playAt = startAt + buffer.duration;
+  };
+
+  const flush = () => {
+    for (const src of queued) { try { src.stop(); } catch {} }
+    queued.clear();
+    playAt = 0;
+  };
+
+  let outputRate = 24000;
+
+  socket.onmessage = async (event) => {
+    if (event.data instanceof ArrayBuffer) {
+      play(new Int16Array(event.data), outputRate);
+      return;
+    }
+    const frame = JSON.parse(event.data);
+
+    if (frame.type === "session.ready") {
+      outputRate = frame.outputSampleRate;
+      await startCapture(frame.inputSampleRate, stream, socket);
+    } else if (frame.type === "speech.started") {
+      flush();                                   // the caller cut in
+    } else if (frame.type === "transcript" && frame.isFinal) {
+      console.log(`${frame.role}: ${frame.text}`);
+    } else if (frame.type === "session.closed") {
+      stream.getTracks().forEach(t => t.stop());
+      playback.close();
+    }
+  };
+
+  return () => socket.send(JSON.stringify({ type: "session.stop" }));
+}
+```
+
+`startCapture` builds an `AudioContext` at the given rate, loads an
+[AudioWorklet](https://developer.mozilla.org/docs/Web/API/AudioWorklet) that converts
+float samples to PCM16, and posts roughly 200 ms per frame to the socket. Keep it in a
+worklet rather than a `ScriptProcessorNode`: capture on the main thread stutters the
+moment your UI does anything.
+
+Route the worklet through a **muted** gain node into the destination. A worklet only
+runs while it is connected to the graph, but the captured microphone must never reach
+the speakers.
+
+## Reading the call back
+
+Every call is recorded, whoever placed it:
+
+```
+GET /api/voice-agents/{voiceAgentId}/sessions?page=1&limit=50
+GET /api/voice-sessions/{voiceSessionId}
+```
+
+The detail response carries the transcript, duration, cost, and every analysis workflow
+the call started — each with an execution id you can open through the normal execution
+API. See [Analysis hooks](analysis.md) for what those workflows receive.
+
+Calls placed with a project API key are marked as real; calls placed from the editor are
+marked `isDebug`, so your dashboards can tell rehearsals from customers.
+
+## Limits
+
+- One token, one call. Re-mint for each.
+- A call is capped by the server's session wall-clock limit; when it hits, you get
+  `session.closed` with `reason: "timeout"`.
+- No telephony (SIP) and no drop-in widget yet. The protocol above is what there is.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
   - Get started: get-started.md
   - Voice agents:
     - What they are: voice-agents/index.md
+    - Integrating a call: voice-agents/integrate.md
     - Analysis hooks: voice-agents/analysis.md
     - Providers: voice-agents/providers.md
   - Creating workflows:


### PR DESCRIPTION
Voice agents were reachable only from the editor. This makes the call a documented public API, and unblocks the MCP server.

## The lockout

The two collection endpoints demanded an explicit `project_id` — in a query string for `GET /voice-agents/`, in the body for `POST /voice-agents/`. That is the shape built for the JWT frontend, where one user spans many projects. A project-scoped `sk_` key carries its own project and cannot supply one, so every programmatic caller was locked out.

Both now go through `resolve_project_id`, the same helper `/workflows` uses. The per-id endpoints and the voice catalog already worked with an API key — nothing else needed changing.

## Real calls are not rehearsals

The session token now records which kind of caller minted it: a JWT is the editor and its calls stay `is_debug`, a project key is someone's product and its calls do not. Without this every real call would have been recorded as a test, and the dashboards would have been unusable the day the first customer called.

## Docs

`docs/voice-agents/integrate.md` documents the protocol as a public contract: minting the token server-side, the frame vocabulary in both directions, why sample rates arrive in `session.ready` rather than being a constant (OpenAI is 24 kHz both ways, Gemini listens at 16 kHz), and why barge-in needs every queued audio source stopped rather than the schedule pointer moved.

The "test-in-editor only" limitation on the overview page is replaced accordingly.

## Note

No tests here by request. The change is a two-line swap to an existing, tested helper plus a claim added to a token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)