### PR TITLE
fix(voice): route realtime conversations through the configured gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,10 @@ PADDLE_PRICE_STARTER=
 PADDLE_PRICE_PRO=
 
 # --- LLM providers ---
+# Transport base URL per provider. Every route to that provider goes through it —
+# chat completions, transcription, and realtime voice conversations. Leave empty
+# for the provider's own endpoint. A gateway used for voice agents must proxy
+# WebSockets, not only HTTP.
 OPENAI_API_BASE_URL=https://api.openai.com/v1
 GEMINI_API_BASE_URL=
 SYSTEM_OPENAI_API_KEY=     # system keys for FREE plan / fallback; blank = self-host BYO-key

--- a/assemblix-app-api/assemblix_api/api/rest/voice_sessions.py
+++ b/assemblix-app-api/assemblix_api/api/rest/voice_sessions.py
@@ -175,7 +175,12 @@ async def stream_voice_session(websocket: WebSocket, token: str) -> None:
         is_debug=scope.is_debug,
     )
     runtime = VoiceSessionRuntime(
-        bridge=create_bridge(provider=setup.provider, api_key=setup.api_key, model=setup.model),
+        bridge=create_bridge(
+            provider=setup.provider,
+            api_key=setup.api_key,
+            model=setup.model,
+            api_base=setup.api_base,
+        ),
         client=_WebSocketChannel(websocket),
         instructions=setup.instructions,
         voice=setup.voice,

--- a/assemblix-app-api/assemblix_api/external/llm/provider_config.py
+++ b/assemblix-app-api/assemblix_api/external/llm/provider_config.py
@@ -48,3 +48,18 @@ PROVIDER_CONFIGS: dict[str, ProviderConfig] = {
 def get_provider_config(provider: str) -> ProviderConfig:
     """Provider config; an unknown provider → the default one (no prefix)."""
     return PROVIDER_CONFIGS.get(provider, ProviderConfig())
+
+
+def resolve_api_base(provider: str) -> str | None:
+    """The configured transport base URL for ``provider``, or None for the default.
+
+    One place, so every route to a provider — chat, transcription, a realtime
+    conversation — goes through the same proxy. An empty setting means "unset";
+    without that check a blank env var would be passed on as a base URL of "".
+    """
+    cfg = get_provider_config(provider)
+    if not cfg.api_base_setting:
+        return None
+    from assemblix_api.core.settings import get_settings
+
+    return getattr(get_settings(), cfg.api_base_setting, None) or None

--- a/assemblix-app-api/assemblix_api/external/voice/conversation/__init__.py
+++ b/assemblix-app-api/assemblix_api/external/voice/conversation/__init__.py
@@ -12,14 +12,23 @@ from assemblix_api.external.voice.conversation.gemini import GeminiLiveBridge
 from assemblix_api.external.voice.conversation.openai import OpenAIRealtimeBridge
 
 
-def create_bridge(*, provider: str, api_key: str, model: str) -> RealtimeBridge:
+def create_bridge(
+    *,
+    provider: str,
+    api_key: str,
+    model: str,
+    api_base: str | None = None,
+) -> RealtimeBridge:
     """Build the conversation bridge for ``provider``.
+
+    ``api_base`` is the configured transport base URL — the same proxy the chat
+    and transcription routes use. ``None`` means the provider SDK's own default.
 
     Raises:
         NotImplementedError: the provider has no conversation route.
     """
     if provider == "openai":
-        return OpenAIRealtimeBridge(api_key=api_key, model=model)
+        return OpenAIRealtimeBridge(api_key=api_key, model=model, api_base=api_base)
     if provider == "gemini":
-        return GeminiLiveBridge(api_key=api_key, model=model)
+        return GeminiLiveBridge(api_key=api_key, model=model, api_base=api_base)
     raise NotImplementedError(f"No conversation route for provider {provider!r}")

--- a/assemblix-app-api/assemblix_api/external/voice/conversation/gemini.py
+++ b/assemblix-app-api/assemblix_api/external/voice/conversation/gemini.py
@@ -74,10 +74,12 @@ class GeminiLiveBridge:
         *,
         api_key: str,
         model: str,
+        api_base: str | None = None,
         connect_factory: Callable[..., Any] | None = None,
     ) -> None:
         self._api_key = api_key
         self._model = model
+        self._api_base = api_base
         self._connect_factory = connect_factory
         self._session: Any = None
         # ``live.connect`` is an @asynccontextmanager. Dropping the manager lets the
@@ -94,8 +96,14 @@ class GeminiLiveBridge:
 
     async def _default_connect(self, *, api_key: str, model: str, config: Any) -> Any:
         from google import genai
+        from google.genai import types
 
-        client = genai.Client(api_key=api_key)
+        # The SDK builds the Live socket URL from http_options.base_url by swapping
+        # the scheme to wss, so a configured gateway is honoured here exactly as it
+        # is for chat and transcription. The gateway has to proxy WebSockets too —
+        # an HTTP-only proxy will fail the handshake rather than fall back.
+        http_options = types.HttpOptions(base_url=self._api_base) if self._api_base else None
+        client = genai.Client(api_key=api_key, http_options=http_options)
         self._manager = client.aio.live.connect(model=model, config=config)
         return await self._manager.__aenter__()
 

--- a/assemblix-app-api/assemblix_api/external/voice/conversation/openai.py
+++ b/assemblix-app-api/assemblix_api/external/voice/conversation/openai.py
@@ -73,10 +73,12 @@ class OpenAIRealtimeBridge:
         *,
         api_key: str,
         model: str,
+        api_base: str | None = None,
         connect_factory: Callable[..., Any] | None = None,
     ) -> None:
         self._api_key = api_key
         self._model = model
+        self._api_base = api_base
         self._connect_factory = connect_factory
         self._connection: Any = None
         self._failed = False
@@ -86,7 +88,10 @@ class OpenAIRealtimeBridge:
     async def _default_connect(self, *, api_key: str, model: str) -> Any:
         from openai import AsyncOpenAI
 
-        client = AsyncOpenAI(api_key=api_key)
+        # The SDK derives the realtime WebSocket URL from the client's base_url, so
+        # routing a conversation through a gateway is the same setting as routing a
+        # chat completion through it. Omitted → the SDK's own default.
+        client = AsyncOpenAI(api_key=api_key, base_url=self._api_base or None)
         manager = client.realtime.connect(model=model)
         return await manager.__aenter__()
 

--- a/assemblix-app-api/assemblix_api/external/voice/transcription.py
+++ b/assemblix-app-api/assemblix_api/external/voice/transcription.py
@@ -15,8 +15,7 @@ from __future__ import annotations
 import litellm
 from pydantic import BaseModel
 
-from assemblix_api.core.settings import get_settings
-from assemblix_api.external.llm.provider_config import get_provider_config
+from assemblix_api.external.llm.provider_config import resolve_api_base
 from assemblix_api.external.voice.catalog import find_voice_model
 from assemblix_api.external.voice.providers import yandex
 
@@ -39,14 +38,6 @@ def _supports_verbose_json(model: str) -> bool:
     check is the accepted approach here. Default stays the universally-safe ``json``.
     """
     return "whisper" in model.lower()
-
-
-def _resolve_api_base(provider: str) -> str | None:
-    """Reuse the chat provider transport config so voice honors the same proxy."""
-    cfg = get_provider_config(provider)
-    if not cfg.api_base_setting:
-        return None
-    return getattr(get_settings(), cfg.api_base_setting, None)
 
 
 async def transcribe(
@@ -78,7 +69,7 @@ async def transcribe(
             model=model,  # bare id, e.g. "whisper-1" (no provider prefix here)
             file=(filename, audio_bytes),
             api_key=api_key,
-            api_base=_resolve_api_base(provider),
+            api_base=resolve_api_base(provider),
             # Only Whisper accepts verbose_json (the source of language/duration);
             # gpt-4o-transcribe* reject it and support json/text only.
             response_format="verbose_json" if _supports_verbose_json(model) else "json",

--- a/assemblix-app-api/assemblix_api/services/voice_session_service.py
+++ b/assemblix-app-api/assemblix_api/services/voice_session_service.py
@@ -33,6 +33,7 @@ from assemblix_api.database.repositories.organization_user_repository import (
 from assemblix_api.database.repositories.project_repository import ProjectRepository
 from assemblix_api.database.repositories.voice_agent_repository import VoiceAgentRepository
 from assemblix_api.database.repositories.voice_session_repository import VoiceSessionRepository
+from assemblix_api.external.llm.provider_config import resolve_api_base
 from assemblix_api.external.voice.catalog.registry import find_voice_model
 from assemblix_api.schemas.voice_agent import VoiceAgentConfig
 from assemblix_api.services.credentials_service import CredentialsService
@@ -64,6 +65,9 @@ class VoiceSessionSetup:
     provider: str
     model: str
     api_key: str
+    # Configured transport base URL — the same gateway chat and transcription use.
+    # None means the provider SDK's own endpoint.
+    api_base: str | None
     turn_workflow_id: str | None
     final_workflow_id: str | None
     # From the voice catalog. A conversation is billed by wall-clock rather than by
@@ -136,6 +140,7 @@ class VoiceSessionService:
             provider=config.voice.provider,
             model=config.voice.model,
             api_key=api_key,
+            api_base=resolve_api_base(config.voice.provider),
             turn_workflow_id=config.turn_workflow_id,
             final_workflow_id=config.final_workflow_id,
             cost_per_minute=(catalog_entry.cost_per_minute or 0.0) if catalog_entry else 0.0,

--- a/internal-docs/CONTRIBUTING_VOICE_AGENTS.md
+++ b/internal-docs/CONTRIBUTING_VOICE_AGENTS.md
@@ -54,6 +54,13 @@ in `session.ready`; the browser builds its capture graph at `inputSampleRate` an
 back at `outputSampleRate`. Nothing anywhere resamples. Getting this wrong produces
 audio that is subtly fast or slow rather than an error.
 
+Honour `api_base`. It is the configured gateway
+(`external/llm/provider_config.py::resolve_api_base`), the same one chat and
+transcription use, and both SDKs derive their WebSocket URL from the client's base
+URL — so wiring it is one argument, and forgetting it sends conversations straight
+to the provider from a network that may not reach it. A gateway also has to proxy
+WebSockets; an HTTP-only one fails the handshake rather than degrading.
+
 Then translate events. The vocabulary is fixed — `AudioDelta`, `UserTranscript`,
 `AgentTranscript`, `SpeechStarted`, `TurnEnded`, `BridgeError`, `SessionClosed` — and
 the runtime above never learns which provider produced them.

--- a/internal-docs/voice-layer-map.md
+++ b/internal-docs/voice-layer-map.md
@@ -125,7 +125,10 @@ the Gemini integration, is [CONTRIBUTING_VOICE_AGENTS.md](CONTRIBUTING_VOICE_AGE
    events into `BridgeEvent`. Nothing provider-shaped may cross that boundary. Declare
    `input_sample_rate` / `output_sample_rate` honestly: they are part of the contract and
    travel to the browser, which builds its capture and playback graphs from them.
-4. `conversation/__init__.py` — one branch.
+4. `conversation/__init__.py` — one branch. Pass `api_base` to the adapter and use
+   it: every other route to a provider honours the configured gateway
+   (`provider_config.resolve_api_base`), and a conversation that quietly ignores it
+   goes straight to the provider from a network that may not reach it.
 5. `credentials_service.py` — add the provider to `_VOICE_PROVIDER_TO_CREDENTIALS_TYPE`,
    or a project's own key will be silently ignored in favour of the system key.
 


### PR DESCRIPTION
Both conversation bridges ignored the provider base-URL setting. A voice call went straight to `api.openai.com` / `generativelanguage.googleapis.com`, while chat completions and transcription for the same provider went through `OPENAI_API_BASE_URL` / `GEMINI_API_BASE_URL`.

On a network that reaches a provider only through a gateway that is the difference between a working call and one that never connects — and nothing in the code hinted at it.

## The fix

Both SDKs derive their WebSocket URL from the client's base URL, so it is one argument each:

- `AsyncOpenAI(base_url=…)`
- `genai.Client(http_options=HttpOptions(base_url=…))`

`api_base` becomes part of the `create_bridge` seam and is resolved in `VoiceSessionService`, so the runtime and the adapters still take no application state.

## Cleanup on the way through

The resolver moved out of `transcription.py` into `provider_config.resolve_api_base`, next to the setting it reads. Three callers now share one answer instead of two copies and a gap. It also treats an empty setting as unset — a blank env var was previously passed on as a base URL of `""`.

## Worth knowing

A gateway used for voice agents has to proxy **WebSockets**, not only HTTP. An HTTP-only proxy fails the handshake rather than degrading into something diagnosable. Stated in `.env.example` and both internal guides.

I could not verify this against a real gateway — `GEMINI_API_BASE_URL` is empty in the local `.env`, so both paths resolve to the SDK default here.

319 tests pass; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)