### PR TITLE
fix(voice): give realtime conversations their own endpoint setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,12 +48,19 @@ PADDLE_PRICE_STARTER=
 PADDLE_PRICE_PRO=
 
 # --- LLM providers ---
-# Transport base URL per provider. Every route to that provider goes through it —
-# chat completions, transcription, and realtime voice conversations. Leave empty
-# for the provider's own endpoint. A gateway used for voice agents must proxy
-# WebSockets, not only HTTP.
+# Transport base URL per provider, for chat completions and transcription.
+# Leave empty for the provider's own endpoint.
 OPENAI_API_BASE_URL=https://api.openai.com/v1
 GEMINI_API_BASE_URL=
+
+# Realtime (speech-to-speech) endpoints for Voice Agents. Separate on purpose: a
+# REST gateway is not automatically a WebSocket gateway, and an LLM proxy that
+# serves /v1/chat/completions answers the realtime route with 404. Leave empty to
+# reach the provider directly; set only once a gateway is known to proxy these:
+#   OpenAI  wss://<base>/realtime
+#   Gemini  wss://<base>/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent
+OPENAI_REALTIME_BASE_URL=
+GEMINI_LIVE_BASE_URL=
 SYSTEM_OPENAI_API_KEY=     # system keys for FREE plan / fallback; blank = self-host BYO-key
 SYSTEM_GEMINI_API_KEY=
 SYSTEM_DEEPSEEK_API_KEY=

--- a/assemblix-app-api/assemblix_api/core/settings.py
+++ b/assemblix-app-api/assemblix_api/core/settings.py
@@ -222,6 +222,15 @@ class Settings(BaseSettings):
     elevenlabs_ws_base_url: str = os.getenv("ELEVENLABS_WS_BASE_URL", "wss://api.elevenlabs.io/v1")
     # PCM wire format for realtime audio (avatar-native; the debug player decodes via Web Audio).
     voice_session_max_seconds: float = float(os.getenv("VOICE_SESSION_MAX_SECONDS", "600"))
+    # Realtime (speech-to-speech) endpoints for Voice Agents, kept separate from the
+    # chat/transcription base URLs above. A REST gateway is not automatically a
+    # WebSocket gateway: an LLM proxy that serves /v1/chat/completions answers the
+    # realtime path with 404. Leave empty to reach the provider directly, and only
+    # set these once a gateway is known to proxy the WebSocket route.
+    #   OpenAI   → wss://<base>/realtime
+    #   Gemini   → wss://<base>/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent
+    openai_realtime_base_url: str = os.getenv("OPENAI_REALTIME_BASE_URL", "")
+    gemini_live_base_url: str = os.getenv("GEMINI_LIVE_BASE_URL", "")
     voice_realtime_output_format: str = os.getenv("VOICE_REALTIME_OUTPUT_FORMAT", "pcm_16000")
     # ElevenLabs chunk_length_schedule — server-side batching to natural boundaries.
     voice_realtime_chunk_schedule: list[int] = [50, 120, 200, 300]

--- a/assemblix-app-api/assemblix_api/services/voice_session_service.py
+++ b/assemblix-app-api/assemblix_api/services/voice_session_service.py
@@ -21,6 +21,7 @@ import structlog
 from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from assemblix_api.core.settings import get_settings
 from assemblix_api.database.repositories.credentials_repository import CredentialsRepository
 from assemblix_api.database.repositories.knowledge_base_repository import KnowledgeBaseRepository
 from assemblix_api.database.repositories.knowledge_document_repository import (
@@ -33,7 +34,6 @@ from assemblix_api.database.repositories.organization_user_repository import (
 from assemblix_api.database.repositories.project_repository import ProjectRepository
 from assemblix_api.database.repositories.voice_agent_repository import VoiceAgentRepository
 from assemblix_api.database.repositories.voice_session_repository import VoiceSessionRepository
-from assemblix_api.external.llm.provider_config import resolve_api_base
 from assemblix_api.external.voice.catalog.registry import find_voice_model
 from assemblix_api.schemas.voice_agent import VoiceAgentConfig
 from assemblix_api.services.credentials_service import CredentialsService
@@ -43,6 +43,23 @@ logger = structlog.get_logger(__name__)
 
 # Credit columns are Numeric(20, 8); anything finer is noise the column cannot hold.
 _CREDITS_QUANTUM = Decimal("0.00000001")
+
+# Where a realtime conversation connects. Deliberately NOT the chat/transcription
+# base URL: a REST gateway that fronts /v1/chat/completions answers the WebSocket
+# route with 404, so pointing conversations at it turns a working call into a dead
+# one. Unset (the default) means talk to the provider directly.
+_CONVERSATION_BASE_URL_SETTINGS = {
+    "openai": "openai_realtime_base_url",
+    "gemini": "gemini_live_base_url",
+}
+
+
+def resolve_conversation_base(provider: str) -> str | None:
+    setting = _CONVERSATION_BASE_URL_SETTINGS.get(provider)
+    if setting is None:
+        return None
+    return getattr(get_settings(), setting, None) or None
+
 
 # A call ends for one of a handful of reasons. Everything else — notably a provider's
 # WebSocket close frame, which is prose and can be any length — is diagnostics, and is
@@ -140,7 +157,7 @@ class VoiceSessionService:
             provider=config.voice.provider,
             model=config.voice.model,
             api_key=api_key,
-            api_base=resolve_api_base(config.voice.provider),
+            api_base=resolve_conversation_base(config.voice.provider),
             turn_workflow_id=config.turn_workflow_id,
             final_workflow_id=config.final_workflow_id,
             cost_per_minute=(catalog_entry.cost_per_minute or 0.0) if catalog_entry else 0.0,

--- a/internal-docs/CONTRIBUTING_VOICE_AGENTS.md
+++ b/internal-docs/CONTRIBUTING_VOICE_AGENTS.md
@@ -54,12 +54,13 @@ in `session.ready`; the browser builds its capture graph at `inputSampleRate` an
 back at `outputSampleRate`. Nothing anywhere resamples. Getting this wrong produces
 audio that is subtly fast or slow rather than an error.
 
-Honour `api_base`. It is the configured gateway
-(`external/llm/provider_config.py::resolve_api_base`), the same one chat and
-transcription use, and both SDKs derive their WebSocket URL from the client's base
-URL — so wiring it is one argument, and forgetting it sends conversations straight
-to the provider from a network that may not reach it. A gateway also has to proxy
-WebSockets; an HTTP-only one fails the handshake rather than degrading.
+Honour `api_base`. Both SDKs derive their WebSocket URL from the client's base
+URL, so it is one argument — but take it from
+`voice_session_service.resolve_conversation_base`, which reads a setting of its own
+(`OPENAI_REALTIME_BASE_URL`, `GEMINI_LIVE_BASE_URL`). Do **not** reuse the
+provider's chat base URL: a REST gateway answers the realtime path with 404, and
+the failure looks like the provider rejecting you rather than like a misrouted
+request. Unset means connect directly, which is the right default.
 
 Then translate events. The vocabulary is fixed — `AudioDelta`, `UserTranscript`,
 `AgentTranscript`, `SpeechStarted`, `TurnEnded`, `BridgeError`, `SessionClosed` — and

--- a/internal-docs/voice-layer-map.md
+++ b/internal-docs/voice-layer-map.md
@@ -125,10 +125,12 @@ the Gemini integration, is [CONTRIBUTING_VOICE_AGENTS.md](CONTRIBUTING_VOICE_AGE
    events into `BridgeEvent`. Nothing provider-shaped may cross that boundary. Declare
    `input_sample_rate` / `output_sample_rate` honestly: they are part of the contract and
    travel to the browser, which builds its capture and playback graphs from them.
-4. `conversation/__init__.py` — one branch. Pass `api_base` to the adapter and use
-   it: every other route to a provider honours the configured gateway
-   (`provider_config.resolve_api_base`), and a conversation that quietly ignores it
-   goes straight to the provider from a network that may not reach it.
+4. `conversation/__init__.py` — one branch. Take `api_base` and use it, but note it
+   comes from `voice_session_service.resolve_conversation_base` — a **separate**
+   setting from the provider's chat/transcription base URL. A REST gateway is not a
+   WebSocket gateway: an LLM proxy that fronts `/v1/chat/completions` answers the
+   realtime route with 404, so reusing that setting turns a working call into a dead
+   one. Unset means talk to the provider directly.
 5. `credentials_service.py` — add the provider to `_VOICE_PROVIDER_TO_CREDENTIALS_TYPE`,
    or a project's own key will be silently ignored in favour of the system key.
 


### PR DESCRIPTION
Follow-up to #64, which merged before this correction was pushed. **Voice calls on main are currently broken for both providers** — see below.

## What #64 got wrong

It routed realtime conversations through the provider's *chat* base URL. A REST gateway is not a WebSocket gateway. With `GEMINI_API_BASE_URL` pointing at a proxy that fronts the generateContent REST surface, the SDK asks it for

```
wss://<proxy>/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent
```

which the proxy has never heard of — the handshake dies on `HTTP 404`.

The same change points OpenAI at `wss://<proxy>/v1/realtime`. That path worked before only because it connected directly, so #64 broke a working provider as well as failing to fix the other.

## The correction

The realtime route gets settings of its own, empty by default meaning "connect directly":

```
OPENAI_REALTIME_BASE_URL=
GEMINI_LIVE_BASE_URL=
```

This is the shape `ELEVENLABS_WS_BASE_URL` already had next to `ELEVENLABS_API_BASE_URL`. The conversation seam should have followed it from the start.

`resolve_api_base` stays where #64 put it — chat and transcription genuinely do share one answer, and that consolidation is still right.

Both exact WebSocket paths are written into `.env.example`, so configuring a gateway does not start with reading a 404.

## Deploy note

Merging this restores direct connections, which is what worked before #64. Whether direct egress to `api.openai.com` and `generativelanguage.googleapis.com` is available from the production network is the open question; if not, the new variables are where a WebSocket-capable gateway goes.

217 unit tests, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)