### PR TITLE
docs: reposition around conversational agents with voice and scoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-**Assemblix** — a visual AI agent / workflow automation platform. Users build workflows
+**Assemblix** — a visual builder for conversational AI agents (text, realtime voice, and
+lip-synced avatars), built on a workflow automation engine. Users build workflows
 as directed graphs of nodes (START, AGENT, CONDITION, SET_VARIABLE, HTTP_REQUEST,
 STICKER, END) on a React Flow canvas, then execute and monitor them. Workflows can call
 multiple LLM providers (OpenAI, Gemini, DeepSeek). The platform supports

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ your own infrastructure with a single `docker compose up`.
 - [📸 Screenshots](#-screenshots)
 - [🧱 How it works](#-how-it-works)
 - [📦 Use it: Demo · Self-host · Enterprise](#-use-it)
+- [🤖 Build it with an AI assistant (MCP)](#-build-it-with-an-ai-assistant-mcp)
 - [🔌 Write your own nodes](#-write-your-own-nodes)
 - [🤝 Contributing](#-contributing)
 - [🔭 Releases & versioning](#-releases--versioning)
@@ -178,6 +179,7 @@ and links straight into the execution viewer.
 | 🔑 **Workflow & voice APIs** | Every workflow is a typed HTTP endpoint; every voice agent has a token-based WebSocket session API. |
 | 🏢 **Multi-tenancy** | Organizations, projects, credentials, and chat sessions out of the box. |
 | 📊 **Observability** | Prometheus `/metrics`, `/health` + `/ready` probes, in-flight executions, per-step LLM token/cost metrics. |
+| 🤖 **MCP server** | Let Claude, Cursor, or any MCP client author, run, and debug workflows and voice agents — one project API key, nothing else to configure. |
 | 🔌 **Node SDK** | Register custom nodes via an entry-point group — auto-discovered at startup. |
 
 <div align="center">
@@ -345,6 +347,35 @@ Billing/payments layer (separate EE license), off by default.
 </tr>
 </table>
 
+## 🤖 Build it with an AI assistant (MCP)
+
+You don't have to build everything by hand. **[assemblix-mcp][mcp-repo]** is an MCP server
+that lets Claude, Cursor, or any MCP client author workflows, run them, read execution
+traces, and manage voice agents on your behalf. **All it needs is one project API key** —
+grab an `sk_…` from the project's **API keys** page and you're done; there is nothing else
+to configure and no `projectId` to pass, because the key already identifies the project.
+
+```bash
+# hosted — nothing to install
+claude mcp add --transport http assemblix https://mcp.assmblx.com \
+  --header "Authorization: Bearer sk_your_key"
+
+# or run it locally against your own instance
+claude mcp add assemblix \
+  --env ASSEMBLIX_API_KEY=sk_your_key \
+  --env ASSEMBLIX_API_URL=http://localhost:8000 \
+  -- uvx assemblix-mcp
+```
+
+It exposes workflow authoring (`create_workflow`, `publish_workflow`, `list_node_types`),
+execution and debugging (`run_workflow_and_wait`, `get_execution_detail`, `list_in_flight`),
+and the full voice agent surface (`create_voice_agent`, `list_voice_calls`, `get_voice_call`)
+— plus guides your assistant can read on how to integrate a workflow or a call into your
+own product.
+
+> `assemblix-mcp` lives in its own repository, **[nmamizerov/assemblix-aitools][mcp-repo]**,
+> under MIT — separate from this one.
+
 ## 🔌 Write your own nodes
 
 Nodes register by string type and are auto-discovered at startup via the `assemblix.nodes`
@@ -404,3 +435,4 @@ small set of files (payments / acquiring) is under a separate **Enterprise licen
 -->
 [demo]: https://app.assmblx.com
 [docs]: https://app.assmblx.com/docs
+[mcp-repo]: https://github.com/nmamizerov/assemblix-aitools

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 <img src="docs/assets/banner.svg" alt="Assemblix" width="380">
 
-### Build AI agents & automations — visually.
+### Build conversational AI agents — visually.
 
-Drag nodes onto a canvas, wire them together, and ship a running AI workflow.
+Design the whole dialogue as a graph, then run it as text, realtime voice, or a
+lip-synced AI avatar — and let workflows score every conversation.
 No glue code. Multi-LLM. Self-hostable. Source-available.
 
 <!-- Badges -->
@@ -30,12 +31,18 @@ No glue code. Multi-LLM. Self-hostable. Source-available.
 
 ---
 
-**Assemblix** is a visual platform for building AI agents and workflow automations. You
-compose workflows as directed graphs of nodes on a [React Flow](https://reactflow.dev)
-canvas — `START → AGENT → CONDITION → HTTP_REQUEST → END` — then execute and monitor them
-in real time. Agents can call any of several LLM providers, branch on logic, call out to
-APIs, read from knowledge bases (RAG), and persist chat sessions. Run it on your own
-infrastructure with a single `docker compose up`.
+**Assemblix** is a visual platform for building **conversational AI agents**. A dialogue
+is not a wall of prompt text here — it is a directed graph of nodes on a
+[React Flow](https://reactflow.dev) canvas (`START → AGENT → CONDITION → HTTP_REQUEST →
+END`) that you can see, branch, and debug turn by turn. Agents call any of several LLM
+providers, carry typed state across turns, answer from your own documents (RAG), and
+reach external APIs mid-conversation.
+
+How the agent *talks* is a separate layer from what it says. The same conversation can
+run as **text**, as **realtime voice** that answers in about half a second, or as a
+**lip-synced AI avatar** — and any conversation can have workflows attached that score
+it, extract data from it, and push the result wherever you need. Run the whole thing on
+your own infrastructure with a single `docker compose up`.
 
 > **Source-available** (MIT + Commons Clause): free to use, modify, and self-host. The
 > commercial billing/payments layer is under a separate Enterprise license and **off by
@@ -44,6 +51,9 @@ infrastructure with a single `docker compose up`.
 ## Contents
 
 - [✨ Why Assemblix](#-why-assemblix)
+- [💡 What you can build](#-what-you-can-build)
+- [🎧 Text, voice, avatar](#-text-voice-avatar)
+- [📈 Every conversation, analyzed](#-every-conversation-analyzed)
 - [🧩 Features](#-features)
 - [🚀 Quickstart (1 minute)](#-quickstart-1-minute)
 - [📸 Screenshots](#-screenshots)
@@ -58,35 +68,126 @@ infrastructure with a single `docker compose up`.
 
 ## ✨ Why Assemblix
 
-- **Visual, not YAML.** Build agent logic by dragging and connecting nodes — see the whole
-  flow at a glance, debug it node-by-node.
-- **Bring your own model.** One canvas, many providers — OpenAI, Gemini, and DeepSeek —
-  with retries, timeouts, and provider/model fallback built in.
+- **A dialogue is a graph, not a prompt.** Branch on what the user said, keep typed state
+  across turns, call an API mid-conversation — and see the whole flow at a glance instead
+  of guessing why one paragraph of instructions misfired.
+- **One agent, three channels.** Text, realtime voice, and lip-synced avatar are layers on
+  top of the same conversation — switch how the agent answers without rebuilding what it
+  says.
+- **Every conversation is analyzed.** Attach workflows to a running dialogue: they score
+  it, pull out the fields you care about, write to your CRM, or raise an alert — in the
+  background, while the conversation keeps going.
+- **It remembers, and it knows your docs.** State lives in Postgres and survives restarts
+  and deploys; knowledge bases ground answers in your own material, with citations.
+- **Bring your own everything.** OpenAI · Gemini · DeepSeek for reasoning, OpenAI Realtime ·
+  Gemini Live for speech-to-speech, ElevenLabs · Yandex SpeechKit for synthesis, Anam for
+  avatars. Your keys, swappable, with retries and fallback built in.
 - **Own your stack.** Self-host the entire thing with Postgres only; Redis + a worker queue
   tier are optional and opt-in. No vendor lock-in, no phone-home.
-- **Production-minded.** SSRF-guarded HTTP node, secrets encryption, Prometheus metrics,
-  health/ready probes, and rate limiting ship in the box.
-- **Extensible by design.** Add a node type as a pip-installable package — it's
-  auto-discovered, no core changes, no DB migration.
+- **Production-minded & extensible.** SSRF-guarded HTTP node, secrets encryption,
+  Prometheus metrics, and rate limiting ship in the box — and a new node type is a
+  pip-installable package, auto-discovered with no core changes.
+
+## 💡 What you can build
+
+Anything shaped like a conversation that someone needs to act on afterwards.
+
+| | | Layers |
+|---|---|---|
+| 📞 **Voice assistants** | Answer calls, book appointments, handle first-line support — the agent replies in about half a second, so it holds a real conversation instead of reading a script. | voice |
+| 🎯 **Lead qualification** | Talk to the lead, then classify and score them in the background and push the result straight into your CRM. | text · voice · analysis |
+| 💼 **Sales agents** | Walk a prospect through the pitch as a branching graph, and grade every conversation against your own criteria. | text · voice · analysis |
+| 🏋️ **Employee training** | The agent plays the difficult customer; an analysis workflow scores how the rep handled it and shows the transcript back with the breakdown. | voice · avatar · analysis |
+| 🎓 **Education & language practice** | Conversational drills and knowledge checks where the agent talks and a workflow marks the answers. | voice · avatar · analysis |
+| 📋 **Interviews & surveys** | Run structured interviews or NPS calls, then extract structured answers from the transcript automatically. | voice · analysis |
+| 📚 **Internal help desk** | Ground an agent on your own PDFs and Markdown and let staff ask it questions in chat or by voice. | text · voice |
+| 🔌 **Agents inside your product** | Every workflow is a typed HTTP endpoint, and every voice agent has a session API — put the conversation behind your own UI. | text · voice |
+
+## 🎧 Text, voice, avatar
+
+The conversation is one thing; the channel it runs in is another. Assemblix keeps them
+separate, so adding voice is a setting rather than a rewrite.
+
+| Layer | What it is |
+|---|---|
+| **Text** | Chat sessions with history and state, plus a typed `POST /api/workflows/…` endpoint for your own front end. |
+| **Voice in a workflow** | A `TRANSCRIBE` node takes speech as input; an `AGENT` node speaks its answer back, buffered or streamed live (ElevenLabs, Yandex SpeechKit). |
+| **Realtime voice agents** | A prompt and a voice running directly against a speech-to-speech model — **no graph on the path to the reply**, so it answers in roughly half a second. |
+| **AI avatars** | An agent's output drives a talking, lip-synced persona (Anam) — the same conversation, with a face. |
+
+**Realtime voice agents** are the newest layer and deliberately *not* a graph. You write a
+prompt, pick a voice, and the caller talks to the model directly:
+
+| If you care most about | Choose |
+|---|---|
+| English conversations that feel natural to interrupt | **OpenAI Realtime** — the crispest barge-in handling |
+| How the agent sounds in Russian or another non-English language | **Gemini Live** — markedly more natural across 70+ languages |
+
+Knowledge bases are inlined into the prompt once when the call starts, so there is no
+retrieval latency mid-call. Every call is recorded with its transcript, duration and cost,
+and the same conversation is available over a public API — your backend mints a
+short-lived session token, your front end streams audio over a WebSocket.
+
+→ [Voice agents](docs/voice-agents/index.md) · [Providers](docs/voice-agents/providers.md) · [Integrating a call](docs/voice-agents/integrate.md)
+
+## 📈 Every conversation, analyzed
+
+This is where the graph engine reaches the dialogue. A conversation can start ordinary
+workflows while it runs, and one more when it ends — extract the caller's details, score
+the call against your criteria, write to a CRM, raise an alert.
+
+Two rules hold: **the conversation never waits** (hooks run in the background), and **the
+result does not come back** (hooks observe, they do not steer).
+
+- **Per-turn hook** — fires on every finished thing the caller says, with the agent's
+  previous reply for context.
+- **Final hook** — fires once when the call ends, with the whole transcript.
+
+```jsonc
+// what the final hook receives
+{
+  "message": "user: hello\nassistant: hi, how can I help?\n…",
+  "voice": {
+    "session_id": "…",
+    "transcript": [{ "role": "user", "text": "hello" }],
+    "duration_sec": 74.2,
+    "end_reason": "user_hangup"
+  }
+}
+```
+
+The workflows are normal workflows — nothing about them is voice-specific, and you run and
+debug them by hand like any other. Every hook run is attached to the call that started it
+and links straight into the execution viewer.
+
+→ [Analysis hooks](docs/voice-agents/analysis.md)
 
 ## 🧩 Features
 
 | | |
 |---|---|
-| 🎨 **Visual canvas** | Drag-and-drop workflow editor (React Flow) with undo/redo, live debug panel, and per-node execution traces. |
+| 🎨 **Visual canvas** | Drag-and-drop dialogue editor (React Flow) with undo/redo, live debug panel, and per-node execution traces. |
 | 🤖 **Multi-LLM agents** | `AGENT` nodes run tool-calling loops against OpenAI · Gemini · DeepSeek, with fallback and backoff. |
+| 🎙️ **Realtime voice agents** | Speech-to-speech conversations on OpenAI Realtime or Gemini Live — sub-second replies, interruptible, recorded. |
+| 🗣️ **Voice in workflows** | `TRANSCRIBE` node for speech input; agent voice output via ElevenLabs or Yandex SpeechKit, buffered or streamed. |
+| 🧑‍💼 **AI avatars** | Drive a lip-synced talking persona (Anam) from an agent's output. |
+| 📈 **Call analysis & scoring** | Per-turn and end-of-call workflow hooks that score conversations, extract fields, and hit your CRM — without blocking the dialogue. |
 | 🔀 **Logic & control flow** | `CONDITION` (CEL expressions), `SET_VARIABLE`, and graph branching to build real decision logic. |
 | 🌐 **HTTP & tools** | `HTTP_REQUEST` node with SSRF protection to call any external API as a tool. |
 | 📚 **Knowledge bases (RAG)** | Attach document knowledge bases to agents for retrieval-augmented answers. |
+| 🔑 **Workflow & voice APIs** | Every workflow is a typed HTTP endpoint; every voice agent has a token-based WebSocket session API. |
 | 🏢 **Multi-tenancy** | Organizations, projects, credentials, and chat sessions out of the box. |
 | 📊 **Observability** | Prometheus `/metrics`, `/health` + `/ready` probes, in-flight executions, per-step LLM token/cost metrics. |
 | 🔌 **Node SDK** | Register custom nodes via an entry-point group — auto-discovered at startup. |
 
 <div align="center">
 
-**Works with the model you already use**
+**Bring your own providers**
 
-<sub>OpenAI&nbsp;&nbsp;·&nbsp;&nbsp;Google Gemini&nbsp;&nbsp;·&nbsp;&nbsp;DeepSeek</sub>
+<sub>**Reasoning** — OpenAI&nbsp;·&nbsp;Google Gemini&nbsp;·&nbsp;DeepSeek</sub><br/>
+<sub>**Realtime speech** — OpenAI Realtime&nbsp;·&nbsp;Gemini Live</sub><br/>
+<sub>**Speech synthesis & transcription** — ElevenLabs&nbsp;·&nbsp;Yandex SpeechKit</sub><br/>
+<sub>**Avatars** — Anam</sub>
 
 </div>
 
@@ -193,6 +294,15 @@ then `docker compose up -d`. Full configuration reference lives in the [docs][do
 | <img src="docs/assets/execution_viewer.png" alt="Execution viewer with per-step input/output and run state" width="420"> | <img src="docs/assets/knowledge_base.png" alt="Knowledge base with uploaded documents" width="420"> |
 | **Chat sessions** | **Agent configuration** |
 | <img src="docs/assets/chat.png" alt="Chat session with a workflow" width="420"> | <img src="docs/assets/agent.png" alt="Agent node configuration panel" width="260"> |
+
+<!--
+  MISSING SHOTS — the voice/avatar layers are not represented above yet.
+  Capture and drop into docs/assets/, then add rows here:
+    voice_agent.png     — the voice agent editor (prompt, provider/voice picker, knowledge)
+    voice_calls.png     — the Calls tab: transcript, duration, cost, linked analysis runs
+    voice_analysis.png  — analysis hooks attached to an agent (per-turn + final workflow)
+    avatar.png          — an agent answering as a lip-synced avatar
+-->
 
 ## 🧱 How it works
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,10 @@
 # Assemblix
 
-**Assemblix** is a visual builder for **chat-driven AI workflows**. You wire typed nodes
+**Assemblix** is a visual builder for **conversational AI agents**. You wire typed nodes
 into a directed graph on a [React Flow](https://reactflow.dev/) canvas, then run it as a
-conversation — with text, **voice**, or a talking **AI avatar** on either end.
+conversation — with text, **voice**, or a talking **AI avatar** on either end. Alongside
+graph workflows it runs **realtime voice agents**: speech-to-speech conversations that
+answer in about half a second, with workflows attached to score and analyze every call.
 
 ![Chat workflow on the canvas](assets/chat.png)
 
@@ -20,7 +22,27 @@ an `END` node produces the reply.
 - **AI avatars** — an agent's output can drive a talking avatar persona, turning a workflow
   into a face-to-face conversation.
 
-## What else you can build
+## Realtime voice agents
+
+A **voice agent** is not a workflow: no canvas, no nodes. You write a prompt, choose a
+voice, and the caller talks to a speech-to-speech model directly — which is why it answers
+fast enough to interrupt. Workflows reach the conversation as **analysis hooks**: they run
+in the background on every turn and once at the end, scoring the call, extracting fields,
+or writing to a CRM.
+
+- **[Voice agents](voice-agents/index.md)** — what you configure, calls, and costs.
+- **[Providers](voice-agents/providers.md)** — OpenAI Realtime vs Gemini Live, honestly.
+- **[Analysis hooks](voice-agents/analysis.md)** — scoring and extracting from a live call.
+- **[Integrating a call](voice-agents/integrate.md)** — the session-token + WebSocket protocol.
+
+## What you can build
+
+Lead qualification and scoring, voice assistants that take calls, sales agents graded
+against your own criteria, employee training where the agent plays the customer, language
+practice and knowledge checks, structured interviews and surveys, and internal help desks
+grounded on your own documents.
+
+## What else is in the box
 
 - **Multiple LLM providers** — OpenAI, Gemini, DeepSeek, with fallbacks and per-credential
   routing.

--- a/docs/voice-agents/integrate.md
+++ b/docs/voice-agents/integrate.md
@@ -13,7 +13,7 @@ The key never reaches the browser, and the token is useless a minute after it is
 ## 1. Mint a session token
 
 ```bash
-curl -X POST https://api.assemblix.ai/api/voice-agents/{voiceAgentId}/sessions \
+curl -X POST https://app.assmblx.com/api/voice-agents/{voiceAgentId}/sessions \
   -H "Authorization: Bearer sk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
 
@@ -31,7 +31,7 @@ The agent must be active; an inactive one returns `400`.
 ## 2. Open the socket
 
 ```
-wss://api.assemblix.ai/api/voice-agents/sessions/{token}/stream
+wss://app.assmblx.com/api/voice-agents/sessions/{token}/stream
 ```
 
 No headers, no auth — the token is in the path, which is what makes this work from a
@@ -92,7 +92,7 @@ async function call(voiceAgentId) {
   });
 
   const socket = new WebSocket(
-    `wss://api.assemblix.ai/api/voice-agents/sessions/${token}/stream`
+    `wss://app.assmblx.com/api/voice-agents/sessions/${token}/stream`
   );
   socket.binaryType = "arraybuffer";
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Assemblix
-site_description: Visual AI agent / workflow automation platform — self-hosting & developer docs
+site_description: Visual builder for conversational AI agents — text, realtime voice, avatars — self-hosting & developer docs
 repo_url: https://github.com/nmamizerov/assemblix
 repo_name: nmamizerov/assemblix
 docs_dir: docs


### PR DESCRIPTION
## Why

The README sold a generic workflow automation platform and never mentioned voice agents at all — despite them now being the product's centre of gravity. This reframes the repository around **conversational agents**: the dialogue is a graph, and text, realtime voice and lip-synced avatars are layers on top of it, with workflows attached as the analysis and scoring engine.

## What changed

**README.md**
- New tagline (`Build conversational AI agents — visually.`), rewritten lead and `Why Assemblix`.
- Three new sections:
  - **💡 What you can build** — eight use cases (voice assistants, lead qualification, sales, employee training, education, interviews, help desk, embedding) with the layers each one leans on.
  - **🎧 Text, voice, avatar** — the layer table, plus realtime voice agents and the honest OpenAI Realtime vs Gemini Live trade-off.
  - **📈 Every conversation, analyzed** — per-turn and final analysis hooks with the JSON payload.
- Feature table gains voice agents, voice in workflows, avatars, call analysis & scoring, and the workflow/voice APIs.
- Provider block split into reasoning / realtime speech / synthesis / avatars.
- Inline comment listing the voice and avatar screenshots still missing from `docs/assets`.

**Docs**
- `docs/index.md` — adds a realtime voice agents section and a use-case paragraph.
- `mkdocs.yml` — `site_description` matches the new framing.
- `CLAUDE.md` — first line matches the new framing.

**Fix**
- `docs/voice-agents/integrate.md` pointed the session-token and WebSocket examples at `api.assemblix.ai`, which is not where the API lives. Now `app.assmblx.com`, consistent with the rest of the docs.

## Not included

The voice and avatar layers are described but not shown — there are no voice agent or avatar screenshots in `docs/assets` yet. The four shots needed are listed in a comment in the Screenshots section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)