### PR TITLE
feat(projects): add key-scoped endpoints for the project state schema

### DIFF
--- a/assemblix-app-api/assemblix_api/api/rest/projects.py
+++ b/assemblix-app-api/assemblix_api/api/rest/projects.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, status
 
+from assemblix_api.api.rest._scope import resolve_project_id
 from assemblix_api.core.auth_context import AuthContext
 from assemblix_api.database.models.organization import Organization
 from assemblix_api.database.models.user import User
@@ -19,9 +20,11 @@ from assemblix_api.dependencies import (
 )
 from assemblix_api.dto.requests.project import (
     ProjectCreateRequest,
+    ProjectStateSchemaUpdateRequest,
     ProjectUpdateRequest,
 )
 from assemblix_api.dto.responses.project import ProjectResponse
+from assemblix_api.schemas import StateVariable
 from assemblix_api.services.project_service import ProjectService
 
 router = APIRouter(prefix="/projects", tags=["Projects"])
@@ -46,6 +49,46 @@ async def list_projects(
         is_active=is_active,
     )
     return projects
+
+
+# Declared before /{project_id} so "state" is not parsed as a project id.
+@router.get("/state", response_model=list[StateVariable])
+async def get_project_state_schema(
+    project_id: UUID | None = Query(
+        default=None,
+        description="Project ID. Optional when authenticated with a project-scoped "
+        "API key - defaults to the key's project.",
+    ),
+    auth: AuthContext = Depends(get_auth_context),
+    service: ProjectService = Depends(get_project_service),
+):
+    """List the project state variables (name, type, default value)."""
+    effective_project_id = resolve_project_id(project_id, auth)
+    project = await service.authorize_project_access(auth, effective_project_id)
+    return project.state_schema
+
+
+@router.put("/state", response_model=list[StateVariable])
+async def update_project_state_schema(
+    data: ProjectStateSchemaUpdateRequest,
+    project_id: UUID | None = Query(
+        default=None,
+        description="Project ID. Optional when authenticated with a project-scoped "
+        "API key - defaults to the key's project.",
+    ),
+    auth: AuthContext = Depends(get_auth_context),
+    service: ProjectService = Depends(get_project_service),
+):
+    """Replace the project state schema with the given variables."""
+    effective_project_id = resolve_project_id(project_id, auth)
+    await service.authorize_project_access(auth, effective_project_id)
+
+    project = await service.update_project(
+        project_id=effective_project_id,
+        user=auth.user,
+        state_schema=[v.model_dump(mode="json") for v in data.state_schema],
+    )
+    return project.state_schema
 
 
 @router.get("/{project_id}", response_model=ProjectResponse)

--- a/assemblix-app-api/assemblix_api/dto/requests/project.py
+++ b/assemblix-app-api/assemblix_api/dto/requests/project.py
@@ -54,3 +54,10 @@ class ProjectUpdateRequest(DTOModel):
         default=None,
         description="Project state schema",
     )
+
+
+class ProjectStateSchemaUpdateRequest(DTOModel):
+    state_schema: list[StateVariable] = Field(
+        ...,
+        description="Full replacement for the project state schema",
+    )

--- a/assemblix-app-api/tests/integration/test_project_state_schema.py
+++ b/assemblix-app-api/tests/integration/test_project_state_schema.py
@@ -1,0 +1,63 @@
+"""Project state schema is readable and replaceable via the scoped /projects/state
+endpoints, which an API key may call without naming its project."""
+
+from __future__ import annotations
+
+VARIABLES = [
+    {"name": "counter", "type": "number", "defaultValue": 0},
+    {"name": "lang", "type": "string", "defaultValue": "ru"},
+]
+
+
+async def test_state_schema_defaults_to_key_project(client, api_key) -> None:
+    # Act
+    resp = await client.get("/api/projects/state", headers=api_key.headers)
+    # Assert
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_update_state_schema_round_trips(client, api_key) -> None:
+    # Act
+    put = await client.put(
+        "/api/projects/state",
+        json={"stateSchema": VARIABLES},
+        headers=api_key.headers,
+    )
+    # Assert: the reply and a fresh read both carry the new variables.
+    assert put.status_code == 200
+    assert put.json() == VARIABLES
+    readback = await client.get("/api/projects/state", headers=api_key.headers)
+    assert readback.json() == VARIABLES
+
+
+async def test_update_state_schema_replaces_previous(client, api_key) -> None:
+    # Arrange
+    await client.put(
+        "/api/projects/state", json={"stateSchema": VARIABLES}, headers=api_key.headers
+    )
+    # Act
+    resp = await client.put(
+        "/api/projects/state",
+        json={"stateSchema": [VARIABLES[1]]},
+        headers=api_key.headers,
+    )
+    # Assert
+    assert resp.json() == [VARIABLES[1]]
+
+
+async def test_state_schema_rejects_foreign_project(client, api_key, auth_headers) -> None:
+    # Arrange: another project in the same org the key is not scoped to.
+    proj = await client.post("/api/projects/", json={"name": "Other"}, headers=auth_headers)
+    other_id = proj.json()["id"]
+    # Act
+    resp = await client.get(f"/api/projects/state?project_id={other_id}", headers=api_key.headers)
+    # Assert
+    assert resp.status_code == 403
+
+
+async def test_state_schema_jwt_without_project_id_returns_400(client, auth_headers) -> None:
+    # Act
+    resp = await client.get("/api/projects/state", headers=auth_headers)
+    # Assert
+    assert resp.status_code == 400


### PR DESCRIPTION
## Why

A project-scoped API key (`sk_...`) cannot name its own project, so the only way to edit project state variables — `PATCH /api/projects/{project_id}` — was unusable from the MCP server. Project state could not be read or edited by an agent at all.

## What

Two endpoints that resolve the project from the key, following the existing `_scope.resolve_project_id` pattern already used by workflows and executions:

- `GET /api/projects/state` — list the state variables.
- `PUT /api/projects/state` — replace them (`{"stateSchema": [...]}`).

`project_id` stays an optional query param: an API key omits it, a JWT caller without it gets 400, and a foreign project gets 403. Both routes are declared **before** `/{project_id}` so `state` is not parsed as a UUID.

The MCP-side tools live in the companion PR on `assemblix-aitools` (`feat/project-state-tools`) and depend on this one — merge and deploy this first, or they will 404.

## Tests

`tests/integration/test_project_state_schema.py` — defaulting to the key's project, round-trip, full-list replacement, 403 on a foreign project, 400 for a JWT caller. Full backend suite: 331 passed; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)