### PR TITLE
feat(voice): carry clientId from a call into its analysis workflows

### DIFF
--- a/assemblix-app-api/alembic/versions/2026_09_07_0637-8992986067da_add_client_id_to_voice_sessions.py
+++ b/assemblix-app-api/alembic/versions/2026_09_07_0637-8992986067da_add_client_id_to_voice_sessions.py
@@ -1,0 +1,29 @@
+"""add client_id to voice_sessions
+
+Revision ID: 8992986067da
+Revises: 4de7fb88cd1f
+Create Date: 2026-09-07 06:37:58.328624
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '8992986067da'
+down_revision = '4de7fb88cd1f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('voice_sessions', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('client_id', sa.String(length=255), nullable=True))
+        batch_op.create_index(
+            batch_op.f('ix_voice_sessions_client_id'), ['client_id'], unique=False
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('voice_sessions', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_voice_sessions_client_id'))
+        batch_op.drop_column('client_id')

--- a/assemblix-app-api/assemblix_api/api/rest/client_sessions.py
+++ b/assemblix-app-api/assemblix_api/api/rest/client_sessions.py
@@ -14,6 +14,7 @@ from assemblix_api.dependencies import (
     get_client_session_service,
     get_execution_service,
     get_project_service,
+    get_voice_session_history_service,
 )
 from assemblix_api.dto.base import PaginatedResponse
 from assemblix_api.dto.requests.client_session import (
@@ -26,10 +27,12 @@ from assemblix_api.dto.responses.client_session import (
     ClientSessionBaseResponse,
 )
 from assemblix_api.dto.responses.execution import ExecutionInfoResponse
+from assemblix_api.dto.responses.voice_session import VoiceSessionResponse
 from assemblix_api.services.chat_service import ChatService
 from assemblix_api.services.client_session_service import ClientSessionService
 from assemblix_api.services.execution_service import ExecutionService
 from assemblix_api.services.project_service import ProjectService
+from assemblix_api.services.voice_session_history_service import VoiceSessionHistoryService
 
 router = APIRouter(prefix="/projects", tags=["Client Sessions"])
 
@@ -309,3 +312,31 @@ async def deactivate_client_session(
         )
 
     await client_session_service.deactivate_session(session.id, project_id)
+
+
+@router.get(
+    "/{project_id}/client-sessions/{client_id}/voice-sessions",
+    response_model=PaginatedResponse[VoiceSessionResponse],
+)
+async def list_client_voice_sessions(
+    project_id: UUID,
+    client_id: str,
+    page: int = Query(default=1, ge=1, description="Page number"),
+    limit: int = Query(default=50, ge=1, le=100, description="Page size"),
+    auth: AuthContext = Depends(get_auth_context),
+    project_service: ProjectService = Depends(get_project_service),
+    voice_history: VoiceSessionHistoryService = Depends(get_voice_session_history_service),
+):
+    """List voice-agent calls placed under this client_id.
+
+    Unlike the executions and chat-sessions tabs, this reads the calls directly by
+    their own client_id rather than through the ClientSession row: a call is stamped
+    when it opens, so it is listed even if it never started a hook workflow.
+    """
+    await project_service.authorize_project_access(auth, project_id)
+
+    sessions, total = await voice_history.list_for_client(
+        project_id, client_id, limit=limit, offset=(page - 1) * limit
+    )
+
+    return PaginatedResponse(data=sessions, total=total, page=page, limit=limit)

--- a/assemblix-app-api/assemblix_api/api/rest/voice_sessions.py
+++ b/assemblix-app-api/assemblix_api/api/rest/voice_sessions.py
@@ -33,6 +33,7 @@ from assemblix_api.dependencies import (
     get_voice_session_history_service,
 )
 from assemblix_api.dto.base import PaginatedResponse
+from assemblix_api.dto.requests.voice_agent import VoiceSessionCreateRequest
 from assemblix_api.dto.responses.voice_session import (
     VoiceSessionDetailResponse,
     VoiceSessionResponse,
@@ -96,11 +97,17 @@ async def get_voice_session(
 @router.post("/{agent_id}/sessions", response_model=VoiceSessionTokenResponse)
 async def create_voice_session(
     agent_id: UUID,
+    request: VoiceSessionCreateRequest | None = None,
     auth: AuthContext = Depends(get_auth_context),
     service: VoiceAgentService = Depends(get_voice_agent_service),
     project_service: ProjectService = Depends(get_project_service),
 ) -> VoiceSessionTokenResponse:
-    """Authorize the caller and hand back a token good for one session."""
+    """Authorize the caller and hand back a token good for one session.
+
+    An optional ``clientId`` in the body is sealed into the token and travels with the
+    call: it lands on the ``voice_sessions`` row and on every analysis-hook run the
+    call starts, so a conversation and its scoring workflows share one ClientSession.
+    """
     agent = await service.get_voice_agent(agent_id)
     await project_service.authorize_project_access(auth, agent.project_id)
 
@@ -117,6 +124,7 @@ async def create_voice_session(
             # A project API key means a program is placing this call from someone's
             # product; a JWT means a person is rehearsing in the editor.
             is_debug=auth.scoped_project_id is None,
+            client_id=request.client_id if request else None,
             ttl_seconds=_TOKEN_TTL_SECONDS,
         ),
         expires_in=_TOKEN_TTL_SECONDS,
@@ -174,6 +182,7 @@ async def stream_voice_session(websocket: WebSocket, token: str) -> None:
             voice_agent_id=scope.voice_agent_id,
             project_id=scope.project_id,
             is_debug=scope.is_debug,
+            client_id=scope.client_id,
         )
     except HTTPException as exc:
         # Notably the plan's concurrent-call ceiling: the browser gets a reason
@@ -199,6 +208,7 @@ async def stream_voice_session(websocket: WebSocket, token: str) -> None:
             voice_session_id=voice_session_id,
             turn_workflow_id=setup.turn_workflow_id,
             final_workflow_id=setup.final_workflow_id,
+            client_id=scope.client_id,
         ),
     )
 

--- a/assemblix-app-api/assemblix_api/database/models/voice_session.py
+++ b/assemblix-app-api/assemblix_api/database/models/voice_session.py
@@ -37,6 +37,11 @@ class VoiceSession(UUIDMixin, TimestampMixin, Base):
         index=True,
     )
 
+    # External identifier of the end-user this call belongs to, as supplied by the
+    # caller when the session token was minted. Carried into every analysis hook so
+    # the call and its scoring runs land on the same ClientSession.
+    client_id: Mapped[str | None] = mapped_column(String(255), default=None, index=True)
+
     status: Mapped[str] = mapped_column(String(20), default="active", nullable=False)
     started_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/assemblix-app-api/assemblix_api/database/repositories/voice_session_repository.py
+++ b/assemblix-app-api/assemblix_api/database/repositories/voice_session_repository.py
@@ -40,6 +40,25 @@ class VoiceSessionRepository(BaseRepository[VoiceSession]):
         )
         return result.scalars().all(), int(total or 0)
 
+    async def list_by_client(
+        self, project_id: UUID, client_id: str, *, limit: int, offset: int
+    ) -> tuple[Sequence[VoiceSession], int]:
+        """Calls one end-user placed in this project, newest first."""
+        where = (self._model.project_id == project_id, self._model.client_id == client_id)
+        stmt = (
+            select(self._model)
+            .where(*where)
+            .order_by(self._model.started_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        result = await self._session.execute(stmt)
+
+        total = await self._session.scalar(
+            select(func.count()).select_from(self._model).where(*where)
+        )
+        return result.scalars().all(), int(total or 0)
+
     async def count_active_by_organization(self, organization_id: UUID, cutoff: datetime) -> int:
         """Live calls of one organisation, ignoring rows stranded by a crashed process."""
         stmt = (

--- a/assemblix-app-api/assemblix_api/dto/requests/voice_agent.py
+++ b/assemblix-app-api/assemblix_api/dto/requests/voice_agent.py
@@ -29,3 +29,15 @@ class VoiceAgentUpdateRequest(DTOModel):
         default=None, description="Full config replacement; omit to leave unchanged"
     )
     is_active: bool | None = None
+
+
+class VoiceSessionCreateRequest(DTOModel):
+    client_id: str | None = Field(
+        default=None,
+        max_length=255,
+        description=(
+            "External client identifier for this call. Ties the session — and every "
+            "analysis-hook workflow it starts — to the same ClientSession, so per-turn "
+            "and final scoring runs share the caller's project state"
+        ),
+    )

--- a/assemblix-app-api/assemblix_api/dto/responses/voice_session.py
+++ b/assemblix-app-api/assemblix_api/dto/responses/voice_session.py
@@ -20,6 +20,9 @@ class VoiceSessionResponse(DTOModel):
 
     id: UUID = Field(description="Unique identifier of the session")
     voice_agent_id: UUID = Field(description="Agent that was called")
+    client_id: str | None = Field(
+        default=None, description="External client identifier this call was tied to"
+    )
     status: str = Field(description="active | completed | failed")
     started_at: datetime = Field(description="When the call started")
     ended_at: datetime | None = Field(default=None, description="When the call ended")

--- a/assemblix-app-api/assemblix_api/realtime/hooks.py
+++ b/assemblix-app-api/assemblix_api/realtime/hooks.py
@@ -42,9 +42,11 @@ class TurnDispatcher:
         voice_session_id: UUID,
         turn_workflow_id: str | None,
         final_workflow_id: str | None,
+        client_id: str | None = None,
         runner: WorkflowRunner | None = None,
     ) -> None:
         self._voice_session_id = voice_session_id
+        self._client_id = client_id
         self._turn_workflow_id = turn_workflow_id
         self._final_workflow_id = final_workflow_id
         self._runner = runner or _default_runner
@@ -101,6 +103,11 @@ class TurnDispatcher:
         task.add_done_callback(self._tasks.discard)
 
     async def _run(self, workflow_id: str, input_data: dict) -> None:
+        # The call's client is the hook's client: a scoring run must land on the same
+        # ClientSession — and therefore the same project state — as the conversation
+        # it analyses.
+        if self._client_id:
+            input_data = {**input_data, "client_id": self._client_id}
         try:
             await self._runner(
                 workflow_id=UUID(workflow_id),

--- a/assemblix-app-api/assemblix_api/realtime/session_token.py
+++ b/assemblix-app-api/assemblix_api/realtime/session_token.py
@@ -32,6 +32,8 @@ class SessionScope:
     # A call placed from the editor is a rehearsal; one placed by a program
     # through a project API key is a real call in someone's product.
     is_debug: bool
+    # Optional end-user identifier the caller tied this call to.
+    client_id: str | None = None
 
 
 def mint_session_token(
@@ -39,6 +41,7 @@ def mint_session_token(
     voice_agent_id: UUID,
     project_id: UUID,
     is_debug: bool,
+    client_id: str | None = None,
     ttl_seconds: int = 60,
 ) -> str:
     settings = get_settings()
@@ -48,6 +51,7 @@ def mint_session_token(
         "agent": str(voice_agent_id),
         "project": str(project_id),
         "debug": is_debug,
+        "client": client_id,
         "iat": int(now.timestamp()),
         "exp": int((now + timedelta(seconds=ttl_seconds)).timestamp()),
     }
@@ -73,6 +77,7 @@ def verify_session_token(token: str) -> SessionScope:
             voice_agent_id=UUID(payload["agent"]),
             project_id=UUID(payload["project"]),
             is_debug=bool(payload.get("debug", False)),
+            client_id=payload.get("client") or None,
         )
     except (KeyError, ValueError) as exc:
         raise InvalidSessionToken("Token is missing its scope") from exc

--- a/assemblix-app-api/assemblix_api/services/voice_session_history_service.py
+++ b/assemblix-app-api/assemblix_api/services/voice_session_history_service.py
@@ -39,6 +39,15 @@ class VoiceSessionHistoryService:
         )
         return [self._to_summary(session) for session in sessions], total
 
+    async def list_for_client(
+        self, project_id: UUID, client_id: str, *, limit: int, offset: int
+    ) -> tuple[list[VoiceSessionResponse], int]:
+        """Calls this end-user placed, across every voice agent of the project."""
+        sessions, total = await self._sessions.list_by_client(
+            project_id, client_id, limit=limit, offset=offset
+        )
+        return [self._to_summary(session) for session in sessions], total
+
     async def get_detail(self, voice_session_id: UUID) -> tuple[VoiceSessionDetailResponse, UUID]:
         """Return the call and the project it belongs to, for the caller to authorize."""
         session = await self._sessions.get_by_id(voice_session_id)
@@ -72,6 +81,7 @@ class VoiceSessionHistoryService:
         return VoiceSessionResponse(
             id=session.id,
             voice_agent_id=session.voice_agent_id,
+            client_id=session.client_id,
             status=session.status,
             started_at=session.started_at,
             ended_at=session.ended_at,

--- a/assemblix-app-api/assemblix_api/services/voice_session_service.py
+++ b/assemblix-app-api/assemblix_api/services/voice_session_service.py
@@ -177,7 +177,12 @@ class VoiceSessionService:
         )
 
     async def open_session(
-        self, *, voice_agent_id: UUID, project_id: UUID, is_debug: bool = True
+        self,
+        *,
+        voice_agent_id: UUID,
+        project_id: UUID,
+        is_debug: bool = True,
+        client_id: str | None = None,
     ) -> UUID:
         """Create the call's row before any audio flows.
 
@@ -214,6 +219,7 @@ class VoiceSessionService:
             project_id=project_id,
             status="active",
             is_debug=is_debug,
+            client_id=client_id,
         )
         return session.id
 
@@ -442,11 +448,18 @@ async def load_voice_session_setup(*, voice_agent_id: UUID, project_id: UUID) ->
 
 
 async def open_voice_session(
-    *, voice_agent_id: UUID, project_id: UUID, is_debug: bool = True
+    *,
+    voice_agent_id: UUID,
+    project_id: UUID,
+    is_debug: bool = True,
+    client_id: str | None = None,
 ) -> UUID:
     async with _voice_session_service() as service:
         return await service.open_session(
-            voice_agent_id=voice_agent_id, project_id=project_id, is_debug=is_debug
+            voice_agent_id=voice_agent_id,
+            project_id=project_id,
+            is_debug=is_debug,
+            client_id=client_id,
         )
 
 

--- a/assemblix-app-api/tests/integration/test_voice_session_hooks.py
+++ b/assemblix-app-api/tests/integration/test_voice_session_hooks.py
@@ -181,3 +181,123 @@ async def test_call_records_transcript_hooks_and_cost(
     assert refreshed is not None
     assert refreshed.session_count == 1
     assert float(refreshed.total_credits) == 64.48333333
+
+
+async def test_client_id_reaches_the_row_and_every_hook(
+    db_session: Any, auth_user: Any, voice_session_service: VoiceSessionService
+) -> None:
+    """A call opened for a client stamps that client on its row and on every analysis
+    hook it starts, so the conversation and its scoring runs share one ClientSession."""
+    # Arrange
+    agent = await VoiceAgentRepository(db_session).create(
+        project_id=auth_user.project_id,
+        name="Receptionist",
+        config={
+            "instructions": [{"role": "system", "content": "Answer calls."}],
+            "voice": {"provider": "openai", "model": "gpt-realtime-2.1", "voiceId": "alloy"},
+            "turnWorkflowId": TURN_WORKFLOW_ID,
+            "finalWorkflowId": FINAL_WORKFLOW_ID,
+        },
+    )
+    voice_session_id = await voice_session_service.open_session(
+        voice_agent_id=agent.id,
+        project_id=auth_user.project_id,
+        client_id="crm-user-42",
+    )
+
+    runner = _RecordingRunner()
+    dispatcher = TurnDispatcher(
+        voice_session_id=voice_session_id,
+        turn_workflow_id=TURN_WORKFLOW_ID,
+        final_workflow_id=FINAL_WORKFLOW_ID,
+        client_id="crm-user-42",
+        runner=runner,
+    )
+
+    # Act — the first hook raises on purpose; the client must still travel with it.
+    dispatcher.dispatch_turn(user_text="Здравствуйте", agent_reply=None, turn_index=0)
+    dispatcher.dispatch_turn(user_text="Запишите меня", agent_reply="Слушаю", turn_index=1)
+    await asyncio.sleep(0)
+    await dispatcher.dispatch_final(
+        transcript=[{"role": "user", "text": "Здравствуйте"}],
+        duration_sec=7.3,
+        end_reason="user_hangup",
+    )
+
+    # Assert
+    assert len(runner.calls) == 3
+    assert all(call["input_data"]["client_id"] == "crm-user-42" for call in runner.calls)
+
+    stored = await VoiceSessionRepository(db_session).get_by_id(voice_session_id)
+    assert stored is not None
+    assert stored.client_id == "crm-user-42"
+
+
+async def test_session_token_round_trips_the_client_id() -> None:
+    """The client is sealed into the session token, so the WebSocket — which carries
+    no body — still knows which client the call belongs to."""
+    # Arrange
+    from uuid import uuid4
+
+    from assemblix_api.realtime.session_token import mint_session_token, verify_session_token
+
+    agent_id, project_id = uuid4(), uuid4()
+
+    # Act
+    with_client = verify_session_token(
+        mint_session_token(
+            voice_agent_id=agent_id,
+            project_id=project_id,
+            is_debug=False,
+            client_id="crm-user-42",
+        )
+    )
+    without_client = verify_session_token(
+        mint_session_token(voice_agent_id=agent_id, project_id=project_id, is_debug=False)
+    )
+
+    # Assert
+    assert with_client.client_id == "crm-user-42"
+    assert without_client.client_id is None
+
+
+async def test_client_page_lists_the_calls_of_that_client(
+    db_session: Any,
+    client: Any,
+    auth_user: Any,
+    auth_headers: dict,
+    voice_session_service: VoiceSessionService,
+) -> None:
+    """The client's page lists that client's calls and nobody else's — including a call
+    that never started a hook, since the stamp is on the call rather than on a run."""
+    # Arrange
+    agent = await VoiceAgentRepository(db_session).create(
+        project_id=auth_user.project_id,
+        name="Receptionist",
+        config={
+            "instructions": [{"role": "system", "content": "Answer calls."}],
+            "voice": {"provider": "openai", "model": "gpt-realtime-2.1", "voiceId": "alloy"},
+        },
+    )
+    mine = await voice_session_service.open_session(
+        voice_agent_id=agent.id, project_id=auth_user.project_id, client_id="crm-user-42"
+    )
+    await voice_session_service.open_session(
+        voice_agent_id=agent.id, project_id=auth_user.project_id, client_id="crm-user-99"
+    )
+    await voice_session_service.open_session(
+        voice_agent_id=agent.id, project_id=auth_user.project_id
+    )
+
+    # Act
+    response = await client.get(
+        f"/api/projects/{auth_user.project_id}/client-sessions/crm-user-42/voice-sessions",
+        headers=auth_headers,
+    )
+
+    # Assert
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert [item["id"] for item in body["data"]] == [str(mine)]
+    assert body["data"][0]["clientId"] == "crm-user-42"

--- a/assemblix-app-web/src/entities/voice-session/api/voice-session.api.ts
+++ b/assemblix-app-web/src/entities/voice-session/api/voice-session.api.ts
@@ -14,6 +14,13 @@ interface ListParams {
   limit?: number;
 }
 
+interface ClientListParams {
+  projectId: string;
+  clientId: string;
+  page?: number;
+  limit?: number;
+}
+
 export const voiceSessionApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     getVoiceSessions: build.query<PaginatedVoiceSessions, ListParams>({
@@ -27,6 +34,19 @@ export const voiceSessionApi = baseApi.injectEndpoints({
       ],
     }),
 
+    getClientVoiceSessions: build.query<PaginatedVoiceSessions, ClientListParams>({
+      query: ({ projectId, clientId, page = 1, limit = 50 }) => ({
+        url: `/projects/${projectId}/client-sessions/${encodeURIComponent(
+          clientId
+        )}/voice-sessions`,
+        method: "GET",
+        params: { page, limit },
+      }),
+      providesTags: (_result, _error, { clientId }) => [
+        { type: "VoiceSessions", id: clientId },
+      ],
+    }),
+
     getVoiceSession: build.query<VoiceSessionDetail, string>({
       query: (id) => ({ url: `/voice-sessions/${id}`, method: "GET" }),
       providesTags: (_result, _error, id) => [{ type: "VoiceSessions", id }],
@@ -34,5 +54,8 @@ export const voiceSessionApi = baseApi.injectEndpoints({
   }),
 });
 
-export const { useGetVoiceSessionsQuery, useGetVoiceSessionQuery } =
-  voiceSessionApi;
+export const {
+  useGetVoiceSessionsQuery,
+  useGetClientVoiceSessionsQuery,
+  useGetVoiceSessionQuery,
+} = voiceSessionApi;

--- a/assemblix-app-web/src/entities/voice-session/index.ts
+++ b/assemblix-app-web/src/entities/voice-session/index.ts
@@ -1,5 +1,6 @@
 export {
   useGetVoiceSessionsQuery,
+  useGetClientVoiceSessionsQuery,
   useGetVoiceSessionQuery,
 } from "./api/voice-session.api";
 export { formatCredits, formatDuration } from "./lib/format";

--- a/assemblix-app-web/src/entities/voice-session/model/types.ts
+++ b/assemblix-app-web/src/entities/voice-session/model/types.ts
@@ -1,6 +1,7 @@
 export interface VoiceSession {
   id: string;
   voiceAgentId: string;
+  clientId: string | null;
   status: "active" | "completed" | "failed";
   startedAt: string;
   endedAt: string | null;

--- a/assemblix-app-web/src/pages/client-session-details/ui/ClientSessionDetailsPage.tsx
+++ b/assemblix-app-web/src/pages/client-session-details/ui/ClientSessionDetailsPage.tsx
@@ -20,6 +20,10 @@ import {
   useUpdateClientSessionMetadataMutation,
   useDeactivateClientSessionMutation,
 } from "@/entities/client-session";
+import {
+  useGetClientVoiceSessionsQuery,
+  VoiceSessionList,
+} from "@/entities/voice-session";
 import { selectCurrentProjectId } from "@/entities/organization";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/shared/ui/tabs";
 import { Button } from "@/shared/ui/button";
@@ -47,6 +51,7 @@ export const ClientSessionDetailsPage = () => {
   const [activeTab, setActiveTab] = useState("overview");
   const [executionsPage, setExecutionsPage] = useState(1);
   const [chatsPage, setChatsPage] = useState(1);
+  const [voicePage, setVoicePage] = useState(1);
   const [editMetadataOpen, setEditMetadataOpen] = useState(false);
   const [deactivateDialogOpen, setDeactivateDialogOpen] = useState(false);
   const [metadataJson, setMetadataJson] = useState("");
@@ -81,6 +86,20 @@ export const ClientSessionDetailsPage = () => {
       },
       { skip: !currentProjectId || !clientId || activeTab !== "chatSessions" }
     );
+
+  const {
+    data: voiceData,
+    isLoading: voiceLoading,
+    isError: voiceError,
+  } = useGetClientVoiceSessionsQuery(
+    {
+      projectId: currentProjectId!,
+      clientId: decodeURIComponent(clientId!),
+      page: voicePage,
+      limit: 10,
+    },
+    { skip: !currentProjectId || !clientId || activeTab !== "voiceSessions" }
+  );
 
   const [updateMetadata, { isLoading: isUpdating }] =
     useUpdateClientSessionMetadataMutation();
@@ -146,6 +165,9 @@ export const ClientSessionDetailsPage = () => {
   const chats = chatsData?.data || [];
   const chatsTotalPages = chatsData ? Math.ceil(chatsData.total / 10) : 0;
 
+  const voiceSessions = voiceData?.data || [];
+  const voiceTotalPages = voiceData ? Math.ceil(voiceData.total / 10) : 0;
+
   return (
     <div className="flex flex-col gap-6">
       {/* Header */}
@@ -178,7 +200,7 @@ export const ClientSessionDetailsPage = () => {
 
       {/* Tabs */}
       <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-        <TabsList className="grid w-full grid-cols-5">
+        <TabsList className="grid w-full grid-cols-6">
           <TabsTrigger value="overview">
             {t("clientSessions.tabs.overview")}
           </TabsTrigger>
@@ -193,6 +215,9 @@ export const ClientSessionDetailsPage = () => {
           </TabsTrigger>
           <TabsTrigger value="chatSessions">
             {t("clientSessions.tabs.chatSessions")}
+          </TabsTrigger>
+          <TabsTrigger value="voiceSessions">
+            {t("clientSessions.tabs.voiceSessions")}
           </TabsTrigger>
         </TabsList>
 
@@ -410,6 +435,24 @@ export const ClientSessionDetailsPage = () => {
                 />
               )}
             </>
+          )}
+        </TabsContent>
+        {/* Voice Sessions Tab */}
+        <TabsContent value="voiceSessions" className="space-y-4">
+          <VoiceSessionList
+            sessions={voiceSessions}
+            isLoading={voiceLoading}
+            isError={voiceError}
+            onOpen={(sessionId) =>
+              navigate(`/projects/${projectId}/voice-sessions/${sessionId}`)
+            }
+          />
+          {voiceTotalPages > 1 && (
+            <Pagination
+              currentPage={voicePage}
+              totalPages={voiceTotalPages}
+              onPageChange={setVoicePage}
+            />
           )}
         </TabsContent>
       </Tabs>

--- a/assemblix-app-web/src/shared/i18n/locales/en.json
+++ b/assemblix-app-web/src/shared/i18n/locales/en.json
@@ -1029,7 +1029,8 @@
       "state": "State",
       "metadata": "Metadata",
       "executions": "Executions",
-      "chatSessions": "Chat Sessions"
+      "chatSessions": "Chat Sessions",
+      "voiceSessions": "Voice Calls"
     }
   },
   "projectSettings": {

--- a/assemblix-app-web/src/shared/i18n/locales/es.json
+++ b/assemblix-app-web/src/shared/i18n/locales/es.json
@@ -1029,7 +1029,8 @@
       "state": "Estado",
       "metadata": "Metadatos",
       "executions": "Ejecuciones",
-      "chatSessions": "Sesiones de chat"
+      "chatSessions": "Sesiones de chat",
+      "voiceSessions": "Llamadas de voz"
     }
   },
   "projectSettings": {

--- a/assemblix-app-web/src/shared/i18n/locales/ru.json
+++ b/assemblix-app-web/src/shared/i18n/locales/ru.json
@@ -1031,7 +1031,8 @@
       "state": "Состояние",
       "metadata": "Метаданные",
       "executions": "Запуски",
-      "chatSessions": "Чат-сессии"
+      "chatSessions": "Чат-сессии",
+      "voiceSessions": "Голосовые звонки"
     }
   },
   "projectSettings": {

--- a/docs/voice-agents/integrate.md
+++ b/docs/voice-agents/integrate.md
@@ -14,12 +14,20 @@ The key never reaches the browser, and the token is useless a minute after it is
 
 ```bash
 curl -X POST https://app.assmblx.com/api/voice-agents/{voiceAgentId}/sessions \
-  -H "Authorization: Bearer sk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  -H "Authorization: Bearer sk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
+  -H "Content-Type: application/json" \
+  -d '{"clientId": "your-end-user-id"}'
 ```
 
 ```json
 { "token": "eyJhbGciOi…", "expiresIn": 60 }
 ```
+
+The body is optional. Its one field:
+
+| Field | Meaning |
+|---|---|
+| `clientId` | Your own identifier for the end-user placing the call. Optional. |
 
 Do this from your server, in response to a request from your own authenticated user —
 the token authorizes exactly one call with one agent, and anyone holding it can place
@@ -27,6 +35,21 @@ that call. Mint it when the user presses the button, not when the page loads: it
 in 60 seconds, and that short life is the whole security model.
 
 The agent must be active; an inactive one returns `400`.
+
+### Tying a call to one of your users
+
+`clientId` is the same identifier `POST /api/executions` takes, and it means the same
+thing here: everything done under it shares one **client session**, and therefore one
+copy of your project state.
+
+Pass it and it is sealed into the token, so it survives into the WebSocket — which
+carries no body of its own. From there it lands on the call itself and on **every
+analysis-hook workflow the call starts**, per-turn and final alike. A scoring workflow
+then reads and writes the same project state your other workflows use for that user,
+which is what makes cumulative scoring across calls and chats possible at all.
+
+Omit it and the call is anonymous: the hooks still run, but with no client session, so
+whatever they write to project state has nowhere to go.
 
 ## 2. Open the socket
 


### PR DESCRIPTION
## The problem

A voice agent's analysis hooks always ran anonymously, and there was no supported way to change that. Three gaps in a row:

- `POST /voice-agents/{id}/sessions` took **no request body**, so a `clientId` sent to it was silently dropped — the endpoint accepted it and ignored it.
- The session token carried only `agent`/`project`/`debug`. Even an accepted `clientId` had nothing to travel on: a WebSocket handshake has neither headers nor a body.
- `TurnDispatcher` built `input_data` from `message` + `voice`. Without a `client_id` key the executor never resolved a `ClientSession`, so `client_session_id` on every hook run was null and whatever the workflow wrote to project state had nowhere to persist.

Reported by an integrator building cumulative call scoring on top of the hooks. Scores were being written per run and adding up to nothing.

## The change

`clientId` now travels end to end:

```
POST /api/voice-agents/{voiceAgentId}/sessions
{ "clientId": "your-end-user-id" }
```

body → sealed into the session token → stamped on the `voice_sessions` row → merged into the `input_data` of **every** hook the call starts, per-turn and final → executor resolves the `ClientSession` and the shared project state.

The body is optional, so existing callers are unaffected and a call minted without it stays anonymous.

### Reading calls back by client

New `GET /api/projects/{projectId}/client-sessions/{clientId}/voice-sessions`, backing a **Voice Calls** tab on the client page in the web UI.

It reads calls by their own `client_id` rather than through the `ClientSession` row — unlike the Executions and Chat Sessions tabs. The stamp goes on the call when it opens, so a call is listed even if its hooks never fired or failed. That was the second half of the integrator's report: calls with no hook runs at all were invisible everywhere.

Calls also expose `clientId` in the API response.

## Notes

- Migration `8992986067da` adds `voice_sessions.client_id` (nullable, indexed). Existing calls stay `null` — the column did not exist when they ran, so they cannot be attributed retroactively.
- The editor's test call still mints anonymously. A rehearsal has no end-user to attribute.
- `docs/voice-agents/integrate.md` now documents the mint request body at all — its absence is what led the integrator to guess the parameter name.

## Testing

Three integration tests: the client reaches the row and all hooks (including one that raises), the token round-trips it, and the client page lists that client's calls and nobody else's. `make check` green — ruff, mypy, bandit, 334 passed. `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)