### PR TITLE
fix(voice): run the final hook even when the caller already hung up

### DIFF
--- a/assemblix-app-api/assemblix_api/realtime/runtime.py
+++ b/assemblix-app-api/assemblix_api/realtime/runtime.py
@@ -99,7 +99,13 @@ class VoiceSessionRuntime:
         return time.monotonic() - self._started_at
 
     async def run(self) -> str:
-        """Drive the session to completion and return the reason it ended."""
+        """Drive the session to completion and return the reason it ended.
+
+        Everything after the pumps stop runs in a ``finally``: by the time a call
+        ends the browser is usually already gone — the client sends
+        ``session.stop`` and closes the socket in the same tick — and the final
+        hook is precisely the thing that has to outlive it.
+        """
         await self._bridge.connect(
             instructions=self._instructions,
             voice=self._voice,
@@ -132,18 +138,22 @@ class VoiceSessionRuntime:
                 task.result()
         finally:
             await self._bridge.close()
+            reason = self._closed_reason or "completed"
 
-        reason = self._closed_reason or "completed"
-        await self._client.send_json({"type": "session.closed", "reason": reason})
+            # Best-effort: a farewell frame nobody is left to receive raises
+            # WebSocketDisconnect, and that must not cost the final hook.
+            with contextlib.suppress(Exception):
+                await self._client.send_json({"type": "session.closed", "reason": reason})
 
-        if self._dispatcher is not None:
-            # The one hook that is awaited: the call is already over, and the whole
-            # point of the final workflow is that it sees the finished transcript.
-            await self._dispatcher.dispatch_final(
-                transcript=self._transcript,
-                duration_sec=self.duration_sec,
-                end_reason=reason,
-            )
+            if self._dispatcher is not None:
+                # The one hook that is awaited: the call is already over, and the
+                # whole point of the final workflow is that it sees the finished
+                # transcript.
+                await self._dispatcher.dispatch_final(
+                    transcript=self._transcript,
+                    duration_sec=self.duration_sec,
+                    end_reason=reason,
+                )
         return reason
 
     async def _pump_client(self) -> None:

--- a/assemblix-app-api/tests/unit/test_voice_session_runtime.py
+++ b/assemblix-app-api/tests/unit/test_voice_session_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from typing import Any
+from uuid import uuid4
 
 from assemblix_api.external.voice.conversation.contract import (
     AgentTranscript,
@@ -13,6 +14,7 @@ from assemblix_api.external.voice.conversation.contract import (
     TurnEnded,
     UserTranscript,
 )
+from assemblix_api.realtime.hooks import TurnDispatcher
 from assemblix_api.realtime.runtime import VoiceSessionRuntime
 
 
@@ -129,3 +131,72 @@ async def test_runtime_drives_a_full_call() -> None:
     }
     assert client.json_frames[-1] == {"type": "session.closed", "reason": "completed"}
     assert bridge.closed is True
+
+
+class _VanishedClient:
+    """A browser that closes the socket in the same tick it hangs up.
+
+    Which is what the shipped web client does: ``stop()`` sends session.stop and
+    tears the socket down immediately, so every write after that raises — exactly
+    as Starlette turns an OSError on a dead socket into WebSocketDisconnect.
+    """
+
+    def __init__(self) -> None:
+        self.json_frames: list[dict] = []
+        self._gone = False
+
+    async def send_json(self, data: dict) -> None:
+        if self._gone:
+            raise RuntimeError("client is gone")
+        self.json_frames.append(data)
+
+    async def send_bytes(self, data: bytes) -> None:
+        if self._gone:
+            raise RuntimeError("client is gone")
+
+    async def __aiter__(self) -> AsyncIterator[Any]:
+        self._gone = True
+        yield {"type": "session.stop"}
+
+
+async def test_final_hook_runs_when_the_browser_is_already_gone() -> None:
+    """A call the caller hung up still runs its final workflow.
+
+    The farewell frame written to a socket nobody is listening on raises, and the
+    final hook used to sit downstream of it — so a normal hangup silently produced
+    no hook run at all: no execution row, no failure, nothing to notice.
+    """
+    # Arrange
+    final_workflow_id = "22222222-2222-2222-2222-222222222222"
+    runs: list[dict] = []
+
+    async def runner(**kwargs: Any) -> None:
+        runs.append(kwargs)
+
+    runtime = VoiceSessionRuntime(
+        bridge=_FakeBridge([UserTranscript(text="здравствуйте", is_final=True)]),
+        client=_VanishedClient(),
+        instructions="Answer calls.",
+        voice="alloy",
+        language="ru",
+        params={},
+        max_session_sec=5,
+        dispatcher=TurnDispatcher(
+            voice_session_id=uuid4(),
+            turn_workflow_id=None,
+            final_workflow_id=final_workflow_id,
+            runner=runner,
+        ),
+    )
+
+    # Act — the runtime may still surface the disconnect to its caller; what it
+    # must not do is skip the hook on the way out.
+    try:
+        await runtime.run()
+    except RuntimeError:
+        pass
+
+    # Assert
+    assert len(runs) == 1, "the final workflow runs even though the socket is dead"
+    assert str(runs[0]["workflow_id"]) == final_workflow_id
+    assert runs[0]["input_data"]["voice"]["end_reason"] == "user_hangup"


### PR DESCRIPTION
## The report

`finalWorkflowId` does not start after a call ends. The call itself looks fine — status `completed`, transcript present — but there is **no execution record at all**: not a successful run, not a failed one. Two agents out of three had never fired the hook once; a third fired it twice and then stopped, with no deploy in between.

The absence of a `FAILED` row is the important clue: an earlier failure (`dc0cf1a6`, a CEL compile error) *was* visible as a row, so the workflow used to at least start. The break is further up the chain.

## Root cause

The final hook sat downstream of a fallible write to a socket that is, by definition, dying at that moment:

```python
reason = self._closed_reason or "completed"
await self._client.send_json({"type": "session.closed", "reason": reason})   # raises
if self._dispatcher is not None:
    await self._dispatcher.dispatch_final(...)                               # unreachable
```

The shipped web client hangs up like this:

```js
socketRef.current.send(JSON.stringify({ type: "session.stop" }));
teardown();   // socket.close(), same tick — it never waits for a reply
```

So the server reads `session.stop`, stops the pumps, and then awaits `bridge.close()` — a network round trip to the provider. By the time it writes the farewell frame the browser is usually gone. Starlette turns the `OSError` on a dead socket into `WebSocketDisconnect` (`starlette/websockets.py`, the `except OSError` branch in `send`), it escapes `run()`, and `dispatch_final` never runs.

The router then does exactly what it should with a disconnect:

```python
except WebSocketDisconnect:
    end_reason = "user_hangup"
finally:
    await close_voice_session(...)   # status completed, transcript written
```

Hence the reported shape: a successful-looking call, a full transcript, and zero trace of the hook anywhere.

Reproduced against the real runtime before the fix:

```
run() RAISED: WebSocketDisconnect
transcript lines: 1
final hook runs: 0
```

### Why it looked intermittent

It is a race, not a switch. The hook survived only when the browser was still attached at the moment of that write — which depends on whether `bridge.close()` reached the provider before the kernel processed the socket teardown. A client that tears down slightly faster, or a provider that closes slightly slower, flips it. That is how the same agent fired hooks for a while and then silently stopped with no code change, and why two integrations never saw one at all.

## The fix

Move the whole tail of the call into a `finally` and make the farewell frame best-effort:

```python
finally:
    await self._bridge.close()
    reason = self._closed_reason or "completed"

    with contextlib.suppress(Exception):
        await self._client.send_json({"type": "session.closed", "reason": reason})

    if self._dispatcher is not None:
        await self._dispatcher.dispatch_final(...)
```

The final workflow is the one thing that has to outlive the socket — it exists precisely to see the finished transcript. It must not be coupled to whether the caller is still on the line.

This also closes the second path to the same symptom: the browser vanishing mid-utterance, where the bridge pump dies on `send_bytes` and takes the tail with it.

## Testing

`test_final_hook_runs_when_the_browser_is_already_gone` models a client that closes in the same tick it hangs up. Verified it fails without the `suppress` and passes with it. `make check` green — 335 passed.

## Not addressed here

Diagnosability is separately poor and this does not change it. A hook that fails before its execution row exists is visible **only in backend logs** — `voice.hook.failed`, `workflow.isolated.not_found`, `workflow.isolated.execution_failed`. From the API an integrator still cannot tell "never dispatched" from "never configured". Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)